### PR TITLE
render dependencies non-obligatory

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,6 +29,3 @@
       - local
       - runner
       - cicd
-  dependencies:
-    - robertdebock.epel
-    - monolithprojects.user_management


### PR DESCRIPTION
As runner setup unfolds well without enforced
spin of roles, currently mandatory dependencies
should be turned optional in logic.