### PR TITLE
Fedora 32 not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This role will deploy or redeploy or uninstall and register or unregister local 
 * Supported Linux distros:
   * CentOS/RHEL 7,8
   * Debian 9,10
-  * Fedora 16+
+  * Fedora 31,30,29,28
   * Ubuntu 16,18
 
 * System must have access to the GitHub.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,10 @@
           - 7
       - name: Fedora
         versions:
-          - all
+          - 28
+          - 29
+          - 30
+          - 31
       - name: Debian
         versions:
           - buster

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,6 +23,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: yes
+    pre_build_image: yes  
+  - name: Fedora31
+    image: monolithprojects/systemd-fedora31:latest
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: yes
     pre_build_image: yes
   - name: Ubuntu16
     image: monolithprojects/systemd-ubuntu16:latest


### PR DESCRIPTION
Edited list of supported platforms in the metadata. Fedora 32 is currently not sported due to `service_facts` Ansible module not being working on this Linux distro. 
Issue has been fixed and will appear in Ansible 2.9.8. https://github.com/ansible/ansible/pull/69303