### PR TITLE
Add the runner_user when the service is installed

### DIFF
--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -75,7 +75,7 @@
     - install
 
 - name: Install service
-  command: "./svc.sh install"
+  command: "./svc.sh install {{ runner_user }}"
   args:
     chdir: "{{ runner_dir }}"
   when: runner_service not in services


### PR DESCRIPTION
When there is a custom `runner_user` the services is installed as `root`.

```bash
Usage:
./svc.sh [install, start, stop, status, uninstall]
Commands:
   install [user]: Install runner service as Root or specified user.
```