### PR TITLE
Download ad unarchive in target machine

### DIFF
--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -35,18 +35,18 @@
 - name: Download runner package version - "{{ runner_version }}" (RUN ONCE)
   get_url:
     url: "https://github.com/actions/runner/releases/download/v{{ runner_version }}/actions-runner-linux-x64-{{ runner_version }}.tar.gz"
-    dest: "./actions-runner-linux-{{ runner_version }}.tar.gz"
+    dest: "/tmp/actions-runner-linux-{{ runner_version }}.tar.gz"
     force: no
   run_once: yes
-  delegate_to: localhost
   tags:
     - install
 
 - name: Unarchive package
   unarchive:
-    src: "./actions-runner-linux-{{ runner_version }}.tar.gz"
+    src: "/tmp/actions-runner-linux-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user }}"
+    remote_src: yes
   tags:
     - install
 


### PR DESCRIPTION
Could be better to download the runner archive on the target machine to avoid local download and unarchive (copy) to the target.
Especially if you don't have a good connection on the local machine.

The archive is 73M