### PR TITLE
[no refs]: conflicts with 'become' and 'delegate_to' methods

### DIFF
--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -23,7 +23,7 @@
     body_format: json
   register: api_response
   run_once: yes
-  delegate_to: localhost
+  #delegate_to: localhost
   when: runner_version == "latest"
   tags:
     - install
@@ -36,18 +36,19 @@
 - name: Download runner package version - "{{ runner_version }}" (RUN ONCE)
   get_url:
     url: "https://github.com/actions/runner/releases/download/v{{ runner_version }}/actions-runner-linux-x64-{{ runner_version }}.tar.gz"
-    dest: "./actions-runner-linux-{{ runner_version }}.tar.gz"
+    dest: "{{ runner_dir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
     force: no
   run_once: yes
-  delegate_to: localhost
+  #delegate_to: localhost
   tags:
     - install
 
 - name: Unarchive package
   unarchive:
-    src: "./actions-runner-linux-{{ runner_version }}.tar.gz"
+    src: "{{ runner_dir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user }}"
+    remote_src: yes
   tags:
     - install
 

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -50,7 +50,6 @@
     src: "./actions-runner-linux-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user }}"
-    #remote_src: yes
   tags:
     - install
 

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -37,7 +37,7 @@
 - name: Download runner package version - "{{ runner_version }}" (RUN ONCE)
   get_url:
     url: "https://github.com/actions/runner/releases/download/v{{ runner_version }}/actions-runner-linux-x64-{{ runner_version }}.tar.gz"
-    dest: "{{ runner_dir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
+    dest: "./actions-runner-linux-{{ runner_version }}.tar.gz"
     force: no
   run_once: yes
   become: false
@@ -47,7 +47,7 @@
 
 - name: Unarchive package
   unarchive:
-    src: "{{ runner_dir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
+    src: "./actions-runner-linux-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user }}"
     #remote_src: yes

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -23,7 +23,8 @@
     body_format: json
   register: api_response
   run_once: yes
-  #delegate_to: localhost
+  become: false
+  delegate_to: localhost
   when: runner_version == "latest"
   tags:
     - install
@@ -39,7 +40,8 @@
     dest: "{{ runner_dir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
     force: no
   run_once: yes
-  #delegate_to: localhost
+  become: false
+  delegate_to: localhost
   tags:
     - install
 
@@ -48,7 +50,7 @@
     src: "{{ runner_dir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user }}"
-    remote_src: yes
+    #remote_src: yes
   tags:
     - install
 


### PR DESCRIPTION
Users may not be the same on controller and remote nodes.
So, if you don't have the same of it, you may run into errors like the follow:

```
fatal: [default]: FAILED! => {
    "changed": false,
    "module_stderr": "Sorry, try again.\n[sudo via ansible, key=random_casual_miao] password:\nsudo: 1 incorrect password attempt\n",",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
The commit solves this problem and can be considered as a patch level