### PR TITLE
fix runner labels generation 

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -30,6 +30,7 @@
     - name: Check Runner
       assert:
         that:
+          - registered_runners.json.runners|json_query('labels[*].name')|flatten|sort == ['Linux', 'self-hosted', 'x86']
           - runner_name in registered_runners.json.runners|map(attribute='name')|list
           - registered_runners.json.runners|map(attribute='status') == ["online"]
         quiet: true

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -89,7 +89,7 @@
 
 - name: Register runner (if new installation) for organization
   command: "{{ runner_dir }}/./config.sh --url {{ github_url }}/{{ github_owner | default(github_account) }} \
-            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels }} --unattended"
+            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended"
   args:
     chdir: "{{ runner_dir }}"
   become: yes
@@ -101,7 +101,7 @@
 
 - name: Replace registered runner for repo
   command: "{{ runner_dir }}/config.sh --url {{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo }} \
-            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels }} --unattended --replace"
+            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended --replace"
   args:
     chdir: "{{ runner_dir }}"
   become: yes
@@ -113,7 +113,7 @@
 
 - name: Replace registered runner for organization
   command: "{{ runner_dir }}/config.sh --url {{ github_url }}/{{ github_owner | default(github_account) }} \
-            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels }} --unattended --replace"
+            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended --replace"
   args:
     chdir: "{{ runner_dir }}"
   become: yes


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes issue with wrong label - `[]` - added for a self-hosted GitHub Actions Runner when using `github_actions_runner` ansible role with default `runner_labels` value (`[]`).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have tried to test it locally with `molecule`, however, it's quite complicated, so please consider it untested locally, and let's rely on CI