### PR TITLE
Custom runner

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ runner_name: "{{ ansible_hostname }}"
 # Labels to apply to the runner
 runner_labels: []
 
+# GitHub repository where releases will be downloaded from
+runner_download_repository: "actions/runner"
+
 # Custom service name when usign Github Enterprise server
 # service_name: actions.runner._services.{{ runner_name }}.service
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ runner_labels: []
 # GitHub repository where releases will be downloaded from
 runner_download_repository: "actions/runner"
 
+# extra arguments to pass to `config.sh`
+runner_extra_config_args: ""
+
 # Custom service name when usign Github Enterprise server
 # service_name: actions.runner._services.{{ runner_name }}.service
 

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -11,7 +11,7 @@
 
 - name: Find the latest runner version (RUN ONCE)
   uri:
-    url: "https://api.github.com/repos/actions/runner/releases/latest"
+    url: "https://api.github.com/repos/{{ runner_download_repository }}/releases/latest"
     headers:
       Content-Type: "application/json"
     method: GET
@@ -54,7 +54,7 @@
 
 - name: Download runner package version - "{{ runner_version }}" (RUN ONCE)
   get_url:
-    url: "https://github.com/actions/runner/releases/download/v{{ runner_version }}/\
+    url: "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\
           actions-runner-linux-{{ github_actions_architecture }}-{{ runner_version }}.tar.gz"
     dest: "{{ runner_pkg_tempdir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
     force: no

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -77,7 +77,8 @@
 
 - name: Register runner (if new installation) for repo
   command: "{{ runner_dir }}/./config.sh --url {{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo }} \
-            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended"
+            --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended \
+            {{ runner_extra_config_args }}"
   args:
     chdir: "{{ runner_dir }}"
   become: yes


### PR DESCRIPTION
## Description

Add support for using runner forks.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I used the following additional configs:
```
- runner_download_repository: "M1cha/gha-custom-runner"
- runner_extra_config_args: "--workerbinary /usr/bin/gha_vm_worker"
```
and it successfully installed the binary from my fork:
https://github.com/M1cha/gha-custom-runner
and passed additional parameters to `config.sh`.