### PR TITLE
Validate the for format of the access_token and runner_org, and improve debug messages

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -24,7 +24,7 @@
 - name: Check runner_org variable (RUN ONCE)
   assert:
     that:
-      - runner_org is bool
+      - runner_org == True or runner_org == False
     fail_msg: "runner_org should be a boolean value"
   run_once: yes
   tags:

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,12 +1,31 @@
 ---
-- name: Check variables (RUN ONCE)
+- name: Check github_account variable (RUN ONCE)
   assert:
     that:
       - github_account is defined
+    fail_msg: "github_account is not defined"
+  run_once: yes
+  tags:
+    - install
+    - uninstall
+
+- name: Check access_token variable (RUN ONCE)
+  assert:
+    that:
       - access_token is defined
       - access_token | length > 0
       - access_token | regex_search('^ghp_')
-    fail_msg: "access_token was not found or invalid"
+    fail_msg: "access_token was not found or is using an invalid format."
+  run_once: yes
+  tags:
+    - install
+    - uninstall
+
+- name: Check runner_org variable (RUN ONCE)
+  assert:
+    that:
+      - runner_org is bool
+    fail_msg: "runner_org should be a boolean value"
   run_once: yes
   tags:
     - install

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -5,7 +5,8 @@
       - github_account is defined
       - access_token is defined
       - access_token | length > 0
-    fail_msg: "access_token was not found."
+      - access_token | regex_search('^ghp_')
+    fail_msg: "access_token was not found or invalid"
   run_once: yes
   tags:
     - install

--- a/tasks/collect_info_org.yml
+++ b/tasks/collect_info_org.yml
@@ -1,6 +1,6 @@
 ---
 - block:
-  - name: Get registration token (RUN ONCE)
+  - name: Get registration token for Orgs (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners/registration-token"
       headers:
@@ -15,7 +15,7 @@
       - install
       - uninstall
 
-  - name: Check currently registered runners (RUN ONCE)
+  - name: Check currently registered runners for Orgs (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
       headers:

--- a/tasks/collect_info_org.yml
+++ b/tasks/collect_info_org.yml
@@ -1,6 +1,6 @@
 ---
 - block:
-  - name: Get registration token for Orgs (RUN ONCE)
+  - name: Get registration token for organization (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners/registration-token"
       headers:
@@ -15,7 +15,7 @@
       - install
       - uninstall
 
-  - name: Check currently registered runners for Orgs (RUN ONCE)
+  - name: Check currently registered runners for organization (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
       headers:

--- a/tasks/collect_info_repo.yml
+++ b/tasks/collect_info_repo.yml
@@ -1,6 +1,6 @@
 ---
 - block:
-  - name: Get registration token (RUN ONCE)
+  - name: Get registration token for non-Orgs (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners/registration-token"
       headers:
@@ -15,7 +15,7 @@
       - install
       - uninstall
 
-  - name: Check currently registered runners (RUN ONCE)
+  - name: Check currently registered runners for non-Orgs (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
       headers:

--- a/tasks/collect_info_repo.yml
+++ b/tasks/collect_info_repo.yml
@@ -1,6 +1,6 @@
 ---
 - block:
-  - name: Get registration token for non-Orgs (RUN ONCE)
+  - name: Get registration token for repo (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners/registration-token"
       headers:
@@ -15,7 +15,7 @@
       - install
       - uninstall
 
-  - name: Check currently registered runners for non-Orgs (RUN ONCE)
+  - name: Check currently registered runners for repo (RUN ONCE)
     uri:
       url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
       headers:

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -32,7 +32,7 @@
     runner_version: "{{ api_response.json.tag_name | regex_replace('^v', '') }}"
   when: runner_version == "latest"
 
-name: Show the runner_version
+- name: Show the runner_version
   debug:
     msg: "runner_version: {{ runner_version }}"
 

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -32,6 +32,10 @@
     runner_version: "{{ api_response.json.tag_name | regex_replace('^v', '') }}"
   when: runner_version == "latest"
 
+name: Show the runner_version
+  debug:
+    msg: "runner_version: {{ runner_version }}"
+
 - name: Check if desired version already installed
   command: "grep -i {{ runner_version }} {{ runner_dir }}/bin/Runner.Listener.deps.json"
   register: runner_installed


### PR DESCRIPTION
# Pull Request Template

## Description

I had to deploy the role for the first time, and I originally faced some problems.

One of my problem was that I set `runner_org: yes` because I thought that it had to be set to this value if the repo is owned by an org.

And then I set the value to `runner_org: "no"` (string instead of boolean), which ended up being interpreted as `true`, and the role kept trying to register my runner as an Org runner.

I struggled to find the problem because when I was trying to identify if the role was trying to register for an Org or for a Repo, I couldn't see which task was using the name `Get registration token (RUN ONCE)`, because both tasks have been declared with the same name in two different files :
```
# grep -rni './' -e 'Get registration token (RUN ONCE)'
.//tasks/collect_info_repo.yml:3:  - name: Get registration token (RUN ONCE)
.//tasks/collect_info_org.yml:3:  - name: Get registration token (RUN ONCE)
```

The other problem I had was that I generated a token using the repository's Action page, which was not a valid Personal Access Token. (see format [here](https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/))

To reduce the probability of other people facing the same problem, I decided to improve a little bit the role by testing the format of the Personal Access Token, and also show in which mode we currently are `Org` vs `non-Org` mode.

List of the changes :
- make sure that the `access_token` match the format for Personal Access Token (should start with `ghp_`)
- updated some tasks' messages to show if we are running in 'Org mode' or 'non-Org mode'
- added debug task to show the version found

## Type of change

- [x] Basic improvements (non-breaking change which improve the usability of the role)

## How Has This Been Tested?

I tested the changes by deploying the role on my server, with different values for the `access_token`, ensuring that the role fails when the `access_token` is not respecting the correct format and with a string value in `runner_org`.

Example of error when the `access_token` does not match the Personal Access Token format :
```
TASK [monolithprojects.github_actions_runner : Check access_token variable (RUN ONCE)] ******************************************************************************************
fatal: [server1]: FAILED! => {
    "assertion": "access_token | regex_search('^ghp_')",
    "changed": false,
    "evaluated_to": false,
    "msg": "access_token was not found or is using an invalid format."
}
```

Example of error when the `runner_org` is set to a string:
```
TASK [monolithprojects.github_actions_runner : Check runner_org variable (RUN ONCE)] ******************************************************************************************
fatal: [server1]: FAILED! => {
    "assertion": "runner_org == True or runner_org == False",
    "changed": false,
    "evaluated_to": false,
    "msg": "runner_org should be a boolean value"
}
```

## Destination branch

Create a PR into `develop` branch