### PR TITLE
Remove ghp_ regex search from assert

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -14,7 +14,6 @@
     that:
       - access_token is defined
       - access_token | length > 0
-      - access_token | regex_search('^ghp_')
     fail_msg: "access_token was not found or is using an invalid format."
   run_once: yes
   tags:


### PR DESCRIPTION
Removed `ghp_` regex search from assert. It's causing the Role fail on GH Enterprise Server which does not have this prefix in the token string.