### PR TITLE
Better ghes support

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,3 @@
-skip_list:  
+skip_list:
   - '106'
+  - ignore-errors

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Personal Access Token for GitHub account can be created [here](https://github.co
 This is a copy from `defaults/main.yml`
 
 ```yaml
+---
 # Runner user - user under which is the local runner service running
 runner_user: "{{ lookup('env','USER') }}"
 
@@ -80,9 +81,6 @@ access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
 # Is it the runner for organization or not?
 runner_org: no
 
-# Name to assign to this runner in GitHub (System hostname as default)
-runner_name: "{{ ansible_hostname }}"
-
 # Labels to apply to the runner
 runner_labels: []
 
@@ -92,7 +90,14 @@ runner_download_repository: "actions/runner"
 # Extra arguments to pass to `config.sh`
 runner_extra_config_args: ""
 
+# Name to assign to this runner in GitHub (System hostname as default)
+runner_name: "{{ ansible_hostname }}"
+
+# Will the runner be deployed on Github Enterprise server?
+runner_on_ghes: no
+
 # Custom service name when usign Github Enterprise server
+# DEPRECATED: this variable is deprecated in favor of "runner_on_ghes" and will be removed in release 1.15.
 # service_name: actions.runner._services.{{ runner_name }}.service
 
 # GitHub Repository user or Organization owner used for Runner registration
@@ -132,7 +137,7 @@ Runner service will be stated and will run under the same user as the Ansible is
     - role: monolithprojects.github_actions_runner
 ```
 
-Same example as above, but runner will be added to an organization.
+Same example as above, but runner will be added to an organization and deployed on GitHub Enterprise Server.
 
 ```yaml
 ---
@@ -142,7 +147,8 @@ Same example as above, but runner will be added to an organization.
   become: yes
   vars:
     - github_account: my_awesome_org
-    - runner_org: true
+    - runner_org: yes
+    - runner_on_ghes: yes
   roles:
     - role: monolithprojects.github_actions_runner
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,9 +32,6 @@ access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
 # Is it the runner for organization or not?
 runner_org: no
 
-# Name to assign to this runner in GitHub (System hostname as default)
-runner_name: "{{ ansible_hostname }}"
-
 # Labels to apply to the runner
 runner_labels: []
 
@@ -43,7 +40,15 @@ runner_download_repository: "actions/runner"
 
 # Extra arguments to pass to `config.sh`
 runner_extra_config_args: ""
+
+# Name to assign to this runner in GitHub (System hostname as default)
+runner_name: "{{ ansible_hostname }}"
+
+# Will the runner be deployed on Github Enterprise server?
+runner_on_ghes: no
+
 # Custom service name when usign Github Enterprise server
+# DEPRECATED: this variable is deprecated in favor of "runner_on_ghes" and will be removed in release 1.15.
 # service_name: actions.runner._services.{{ runner_name }}.service
 
 # GitHub Repository user or Organization owner used for Runner registration

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,6 +9,7 @@
     - github_repo: ansible-github_actions_runner-testrepo
     - github_account: monolithprojects-testorg
     - runner_version: "latest"
+    - service_name: awesome
     - runner_labels:
         - label1
         - repo-runner

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -29,3 +29,14 @@
   tags:
     - install
     - uninstall
+
+- name: GHES service_name deprecation check (RUN ONCE)
+  assert:
+    that:
+      - service_name is not defined
+    fail_msg: '[DEPRECATION WARNING]: Variable "service_name" will is deprecated and will be removed in release 1.15. Start using "running_on_ghes" boolean variable.'
+  ignore_errors: yes
+  run_once: yes
+  tags:
+    - install
+    - uninstall

--- a/tasks/collect_info_org.yml
+++ b/tasks/collect_info_org.yml
@@ -37,7 +37,7 @@
       - install
       - uninstall
 
-  - name: Build service name
+  - name: Build service name for github.com
     set_fact:
       runner_service: "actions.runner.{{ ([( github_owner | default(github_account))[:45], runner_name] | join('.'))[:57]  }}.service"
     when: not runner_on_ghes
@@ -52,3 +52,13 @@
     tags:
       - install
       - uninstall
+
+  - name: Build service name for GitHub Enterprise Server (Left for backward compatibility. This task will be removed in v1.15)
+    set_fact:
+      runner_service: "{{ service_name }}"
+    when: service_name is defined
+    tags:
+      - install
+      - uninstall
+
+  check_mode: false

--- a/tasks/collect_info_org.yml
+++ b/tasks/collect_info_org.yml
@@ -40,16 +40,15 @@
   - name: Build service name
     set_fact:
       runner_service: "actions.runner.{{ ([( github_owner | default(github_account))[:45], runner_name] | join('.'))[:57]  }}.service"
-    when: service_name is not defined
+    when: not runner_on_ghes
     tags:
       - install
       - uninstall
 
-  - name: Build service name
+  - name: Build service name for GitHub Enterprise Server
     set_fact:
-      runner_service: "{{ service_name }}"
-    when: service_name is defined
+      runner_service: "actions.runner._services.{{ ([( github_owner | default(github_account))[:45], runner_name] | join('.'))[:57]  }}.service"
+    when: runner_on_ghes
     tags:
       - install
       - uninstall
-  check_mode: false

--- a/tasks/collect_info_repo.yml
+++ b/tasks/collect_info_repo.yml
@@ -51,3 +51,13 @@
     tags:
       - install
       - uninstall
+
+  - name: Build service name for GitHub Enterprise Server (Left for backward compatibility. This task will be removed in v1.15)
+    set_fact:
+      runner_service: "{{ service_name }}"
+    when: service_name is defined
+    tags:
+      - install
+      - uninstall
+
+  check_mode: false

--- a/tasks/collect_info_repo.yml
+++ b/tasks/collect_info_repo.yml
@@ -36,19 +36,18 @@
       - install
       - uninstall
 
-  - name: Build service name
+  - name: Build service name for github.com
     set_fact:
       runner_service: "actions.runner.{{ ([([(github_owner | default(github_account)), github_repo ] | join('-'))[:45], runner_name] | join('.'))[:57] }}.service"
-    when: service_name is not defined
+    when: not runner_on_ghes
     tags:
       - install
       - uninstall
 
-  - name: Build service name
+  - name: Build service name for GitHub Enterprise Server
     set_fact:
-      runner_service: "{{ service_name }}"
-    when: service_name is defined
+      runner_service: "actions.runner._services.{{ ([([(github_owner | default(github_account)), github_repo ] | join('-'))[:45], runner_name] | join('.'))[:57] }}.service"
+    when: runner_on_ghes
     tags:
       - install
       - uninstall
-  check_mode: false


### PR DESCRIPTION
# Pull Request Template

## Description

Because of different service names for GH Actions Runner running against github.com and GitHub Enterprise Sever (`service_name: actions.runner.{{ runner_name }}.service` vs `service_name: actions.runner._services.{{ runner_name }}.service` ) GHES users had to use `service_name` variable to get their runner service name built correctly. This option was not clear enough and caused confusion.
This PR will deprecate `service_name` in favor of `runner_on_ghes` boolean variable. Now the users only need to set if the runner will run on GHES or not and the service name will be crated correctly.

I am keeping also backward compatibility.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Was not tested on GHES.

## Destination branch

Create a PR into `develop` branch