### PR TITLE
Fix service name

### DIFF
--- a/tasks/collect_info_org.yml
+++ b/tasks/collect_info_org.yml
@@ -39,7 +39,7 @@
 
   - name: Build service name for github.com
     set_fact:
-      runner_service: "actions.runner.{{ ([( github_owner | default(github_account))[:45], runner_name] | join('.'))[:57]  }}.service"
+      runner_service: "actions.runner.{{ ([( github_owner | default(github_account))[:45], ( runner_name ) | replace(' ','_')] | join('.'))[:57]  }}.service"
     when: not runner_on_ghes
     tags:
       - install
@@ -47,7 +47,7 @@
 
   - name: Build service name for GitHub Enterprise Server
     set_fact:
-      runner_service: "actions.runner._services.{{ runner_name }}.service"
+      runner_service: "actions.runner._services.{{ ( runner_name ) | replace(' ','_') }}.service"
     when: runner_on_ghes
     tags:
       - install

--- a/tasks/collect_info_org.yml
+++ b/tasks/collect_info_org.yml
@@ -47,7 +47,7 @@
 
   - name: Build service name for GitHub Enterprise Server
     set_fact:
-      runner_service: "actions.runner._services.{{ ([( github_owner | default(github_account))[:45], runner_name] | join('.'))[:57]  }}.service"
+      runner_service: "actions.runner._services.{{ runner_name }}.service"
     when: runner_on_ghes
     tags:
       - install

--- a/tasks/collect_info_repo.yml
+++ b/tasks/collect_info_repo.yml
@@ -38,7 +38,7 @@
 
   - name: Build service name for github.com
     set_fact:
-      runner_service: "actions.runner.{{ ([([(github_owner | default(github_account)), github_repo ] | join('-'))[:45], runner_name] | join('.'))[:57] }}.service"
+      runner_service: "actions.runner.{{ ([([(github_owner | default(github_account)), github_repo ] | join('-'))[:45], ( runner_name ) | replace(' ','_')] | join('.'))[:57] }}.service"
     when: not runner_on_ghes
     tags:
       - install
@@ -46,7 +46,7 @@
 
   - name: Build service name for GitHub Enterprise Server
     set_fact:
-      runner_service: "actions.runner._services.{{ runner_name }}.service"
+      runner_service: "actions.runner._services.{{ ( runner_name ) | replace(' ','_') }}.service"
     when: runner_on_ghes
     tags:
       - install

--- a/tasks/collect_info_repo.yml
+++ b/tasks/collect_info_repo.yml
@@ -46,7 +46,7 @@
 
   - name: Build service name for GitHub Enterprise Server
     set_fact:
-      runner_service: "actions.runner._services.{{ ([([(github_owner | default(github_account)), github_repo ] | join('-'))[:45], runner_name] | join('.'))[:57] }}.service"
+      runner_service: "actions.runner._services.{{ runner_name }}.service"
     when: runner_on_ghes
     tags:
       - install


### PR DESCRIPTION
# Description

According to issue [Custom service names appear to be broken #74](https://github.com/MonolithProjects/ansible-github_actions_runner/issues/74), the service name was not fixed by PR [#106](https://github.com/MonolithProjects/ansible-github_actions_runner/pull/106). 

So I had an error on playbook task `monolithprojects.github_actions_runner : START and enable Github Actions Runner service`:
`"Could not find the requested service actions.runner._services.organisation-repo.hostname.service: host"`

Indeed, the service name on GHES should be: `actions.runner._services.<RUNNER_NAME>.service`

Also, I noticed that I can put spaces into my runner_name, but the service name should have spaces replaced by underscores. This affect GHES and Github.com

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Minor change (pipeline, tests, spelling ...)

## How Has This Been Tested?

I tested my changes on Ubuntu 20.04, with GitHub runner 2.278.0 and latest (2.235.0), and with `runner_org: no`, `runner_org: yes`.

## Destination branch

Create a PR into `develop` branch
