### PR TITLE
Add runner group option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ runner_org: no
 # Labels to apply to the runner
 runner_labels: []
 
+# Group to add organization runner to
+runner_group: ""
+
 # GitHub Actions Runner repository (change it if you want to use custom Actions Runner fork)
 runner_download_repository: "actions/runner"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,9 @@ runner_org: no
 # Labels to apply to the runner
 runner_labels: []
 
+# Group to add organization runner to
+runner_group: ""
+
 # GitHub Actions Runner repository (change it if you want to use custom Actions Runner fork)
 runner_download_repository: "actions/runner"
 

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -110,7 +110,8 @@
 - name: Register runner (if new installation) for organization
   command:
     "{{ runner_dir }}/./config.sh --url {{ github_url }}/{{ github_owner | default(github_account) }} \
-    --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended \
+    --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} \
+    --runnergroup {{ runner_group }} --unattended \
     {{ runner_extra_config_args }}"
   args:
     chdir: "{{ runner_dir }}"
@@ -138,8 +139,8 @@
 - name: Replace registered runner for organization
   command:
     "{{ runner_dir }}/config.sh --url {{ github_url }}/{{ github_owner | default(github_account) }} \
-    --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} --unattended \
-    {{ runner_extra_config_args }} --replace"
+    --token {{ registration.json.token }} --name {{ runner_name }} --labels {{ runner_labels | join(',') }} \
+    --runnergroup {{ runner_group }} --unattended {{ runner_extra_config_args }} --replace"
   args:
     chdir: "{{ runner_dir }}"
   become: yes


### PR DESCRIPTION
# Description

This fixes issue #119 by adding an option to configure a runner group for org runners. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X ] This change requires a documentation update
- [ ] Minor change (pipeline, tests, spelling ...)

## How Has This Been Tested?

Manually tested this change by testing this against a debian machine with a github org I own.

## Destination branch

Create a PR into `develop` branch
