### PR TITLE
Fix a bug when there is spaces in runner_name

### DIFF
--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -96,7 +96,7 @@
     "{{ runner_dir }}/./config.sh \
     --url {{ github_full_url }} \
     --token {{ registration.json.token }} \
-    --name {{ runner_name }} \
+    --name '{{ runner_name }}' \
     --labels {{ runner_labels | join(',') }} \
     --runnergroup {{ runner_group }} \
     --unattended \

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -113,7 +113,7 @@
     "{{ runner_dir }}/config.sh \
     --url {{ github_full_url }} \
     --token {{ registration.json.token }} \
-    --name {{ runner_name }} \
+    --name '{{ runner_name }}' \
     --labels {{ runner_labels | join(',') }} \
     --unattended \
     {{ runner_extra_config_args }} \

--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -17,7 +17,7 @@
   register: runner_file
 
 - name: Unregister runner from the GitHub
-  command: "./config.sh remove --token {{ registration.json.token }} --name {{ runner_name }} --unattended"
+  command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
   args:
     chdir: "{{ runner_dir }}"
   become_user: "{{ runner_user }}"


### PR DESCRIPTION
# Description

The runner_name is not created properly if there is a space inside, so the script config.sh get the first word. After that the service is created with the first word only but ansible search to start a service with full name.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

I ran a playbook with runner_name: "Ansible test" and now I can see "Ansible test" in my runners list. Previously it was "Ansible". Also I didn't had the error to start the service anymore.

PS: I use GHES but it should not be important in this case.