### PR TITLE
Ref #135 - Correct teardown permissions

### DIFF
--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -20,6 +20,7 @@
   command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
   args:
     chdir: "{{ runner_dir }}"
+  become: yes
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name in registered_runners.json.runners|map(attribute='name')|list and runner_file.stat.exists


### PR DESCRIPTION
# Description

Corrects #135, tearing down the runner raises a permissions error.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Altered the galaxy role locally and ran it.