### PR TITLE
Download Runner package directly to the runner node 

### DIFF
--- a/.github/RELEASE_DRAFTER.yml
+++ b/.github/RELEASE_DRAFTER.yml
@@ -14,6 +14,19 @@ categories:
     label: 'documentation'
   - title: 'CI'
     label: 'ci'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'enhancement'
+      - 'feature'
+  patch:
+    labels:
+      - 'ci'
+      - 'bug'
+  default: patch
 change-template: '- $TITLE, by @$AUTHOR (#$NUMBER)'
 template: |
   # What's changed

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ runner_user: "{{ lookup('env','USER') }}"
 # Directory where the local runner will be installed
 runner_dir: /opt/actions-runner
 
-# Directory where the runner package will be dowloaded
-runner_pkg_tempdir: /tmp/gh_actions_runner
-
 # Version of the GitHub Actions Runner
 runner_version: "latest"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,6 @@ runner_user: "{{ lookup('env','USER') }}"
 # Directory where the local runner will be installed
 runner_dir: /opt/actions-runner
 
-# Directory where the runner package will be dowloaded
-runner_pkg_tempdir: /tmp/gh_actions_runner
-
 # Version of the GitHub Actions Runner
 runner_version: "latest"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 # handlers file for ansible-github_actions_runner (currently not used)
 - name: Restart runner service
-  service:
-   name: "{{ runner_service }}"
-   state: restarted
+  ansible.builtin.service:
+    name: "{{ runner_service }}"
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@
     description: Deploy Github Actions private runner
     company: MonolithProjects
     license: "license (MIT)"
-    min_ansible_version: 2.9.8
+    min_ansible_version: 2.10
     platforms:
       - name: EL
         versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,40 +1,29 @@
 ---
-  galaxy_info:
-    author: Michal Muransky
-    role_name: github_actions_runner
-    namespace: monolithprojects
-    description: Deploy Github Actions private runner
-    company: MonolithProjects
-    license: "license (MIT)"
-    min_ansible_version: 2.10
-    platforms:
-      - name: EL
-        versions:
-          - 6
-          - 7
-          - 8
-      - name: Fedora
-        versions:
-          - 31
-          - 32
-          - 33
-          - 34
-          - 35
-          - 36
-      - name: Debian
-        versions:
-          - bullseye
-          - buster
-          - stretch
-      - name: Ubuntu
-        versions:
-          - xenial
-          - bionic
-          - focal
-    galaxy_tags:
-      - github
-      - actions
-      - private
-      - local
-      - runner
-      - cicd
+galaxy_info:
+  author: Michal Muransky
+  role_name: github_actions_runner
+  namespace: monolithprojects
+  description: Deploy Github Actions private runner
+  company: MonolithProjects
+  license: "license (MIT)"
+  min_ansible_version: "2.10"
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+  galaxy_tags:
+    - github
+    - actions
+    - private
+    - local
+    - runner
+    - cicd

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,13 +1,13 @@
 ---
 - name: Check github_account variable (RUN ONCE)
-  assert:
+  ansible.builtin.assert:
     that:
       - github_account is defined
     fail_msg: "github_account is not defined"
   run_once: yes
 
 - name: Check access_token variable (RUN ONCE)
-  assert:
+  ansible.builtin.assert:
     that:
       - access_token is defined
       - access_token | length > 0
@@ -15,7 +15,7 @@
   run_once: yes
 
 - name: Check runner_org variable (RUN ONCE)
-  assert:
+  ansible.builtin.assert:
     that:
       - runner_org | bool == True or runner_org == False
     fail_msg: "runner_org should be a boolean value"

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -1,17 +1,17 @@
 ---
 - block:
   - name: Set complete API url for repo runner
-    set_fact:
+    ansible.builtin.set_fact:
       github_full_api_url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
     when: not runner_org
 
   - name: Set complete API url for org runner
-    set_fact:
+    ansible.builtin.set_fact:
       github_full_api_url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
     when: runner_org | bool
 
   - name: Get registration token (RUN ONCE)
-    uri:
+    ansible.builtin.uri:
       url: "{{ github_full_api_url }}/registration-token"
       headers:
         Authorization: "token {{ access_token }}"
@@ -23,7 +23,7 @@
     run_once: yes
 
   - name: Check currently registered runners for repo (RUN ONCE)
-    uri:
+    ansible.builtin.uri:
       url: "{{ github_full_api_url }}"
       headers:
         Authorization: "token {{ access_token }}"
@@ -35,6 +35,6 @@
     run_once: yes
 
   - name: Check service facts
-    service_facts:
+    ansible.builtin.service_facts:
 
   check_mode: false

--- a/tasks/install_deps.yml
+++ b/tasks/install_deps.yml
@@ -1,7 +1,7 @@
 ---
 # All dependencies derived from https://github.com/actions/runner/blob/main/docs/start/envlinux.md
 - name: Install dependencies on Debian Stretch
-  package:
+  ansible.builtin.package:
     pkg:
       - acl
       - liblttng-ust0
@@ -14,7 +14,7 @@
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "9")
 
 - name: Install dependencies on Debian Buster
-  package:
+  ansible.builtin.package:
     pkg:
       - acl
       - liblttng-ust0
@@ -27,7 +27,7 @@
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
 
 - name: Install dependencies on Debian Bullseye
-  package:
+  ansible.builtin.package:
     pkg:
       - acl
       - liblttng-ust0
@@ -40,7 +40,7 @@
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "11")
 
 - name: Install dependencies on Ubuntu Xenial systems
-  package:
+  ansible.builtin.package:
     pkg:
       - acl
       - liblttng-ust0
@@ -53,7 +53,7 @@
   when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16")
 
 - name: Install dependencies on Ubuntu Bionic systems
-  package:
+  ansible.builtin.package:
     pkg:
       - acl
       - liblttng-ust0
@@ -66,7 +66,7 @@
   when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18")
 
 - name: Install dependencies on Ubuntu Focal systems
-  package:
+  ansible.builtin.package:
     pkg:
       - acl
       - liblttng-ust0
@@ -79,7 +79,7 @@
   when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "20")
 
 - name: Install dependencies on RHEL/CentOS/Fedora systems
-  package:
+  ansible.builtin.package:
     name:
       - acl
       - lttng-ust

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -1,13 +1,13 @@
 ---
 - name: Create directory
-  file:
+  ansible.builtin.file:
     path: "{{ runner_dir }}"
     state: directory
     mode: 0755
     owner: "{{ runner_user }}"
 
 - name: Find the latest runner version (RUN ONCE)
-  uri:
+  ansible.builtin.uri:
     url: "https://api.github.com/repos/{{ runner_download_repository }}/releases/latest"
     headers:
       Content-Type: "application/json"
@@ -23,50 +23,46 @@
   when: runner_version == "latest"
 
 - name: Set runner_version variable (If latest)
-  set_fact:
+  ansible.builtin.set_fact:
     runner_version: "{{ api_response.json.tag_name | regex_replace('^v', '') }}"
   when: runner_version == "latest"
 
 - name: Check if desired version already installed
-  command: "grep -i {{ runner_version }} {{ runner_dir }}/bin/Runner.Listener.deps.json"
+  ansible.builtin.command: "grep -i {{ runner_version }} {{ runner_dir }}/bin/Runner.Listener.deps.json"
   register: runner_installed
   check_mode: false
   changed_when: False
   ignore_errors: yes
 
 - name: Create temporary directory for archive
-  file:
-    path: "{{ runner_pkg_tempdir }}"
+  ansible.builtin.tempfile:
     state: directory
-    recurse: yes
-    mode: 0777
-  run_once: yes
-  delegate_to: localhost
+    suffix: runner
   become: false
+  register: temp_dir
   when: runner_version not in runner_installed.stdout
 
 - name: Download runner package version - "{{ runner_version }}" (RUN ONCE)
-  get_url:
+  ansible.builtin.get_url:
     url:
       "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\
       actions-runner-linux-{{ github_actions_architecture }}-{{ runner_version }}.tar.gz"
-    dest: "{{ runner_pkg_tempdir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
+    dest: "{{ temp_dir.path }}/actions-runner-linux-{{ runner_version }}.tar.gz"
     force: no
-  run_once: yes
   become: false
-  delegate_to: localhost
   when: runner_version not in runner_installed.stdout or reinstall_runner
 
 - name: Unarchive package
-  unarchive:
-    src: "{{ runner_pkg_tempdir }}/actions-runner-linux-{{ runner_version }}.tar.gz"
+  ansible.builtin.unarchive:
+    src: "{{ temp_dir.path }}/actions-runner-linux-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user }}"
+    remote_src: yes
     mode: 0755
   when: runner_version not in runner_installed.stdout or reinstall_runner
 
 - name: Configure custom env file if required
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: "{{ runner_dir }}/.env"
     block: "{{ custom_env }}"
     owner: "{{ runner_user }}"
@@ -77,22 +73,22 @@
   when: custom_env is defined
 
 - name: Check if runner service name file exist
-  stat:
+  ansible.builtin.stat:
     path: "{{ runner_dir }}/.service"
   register: runner_service_file_path
 
 - name: Set complete GitHub url for repo runner
-  set_fact:
+  ansible.builtin.set_fact:
     github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo }}"
   when: not runner_org
 
 - name: Set complete GitHub url for org runner
-  set_fact:
+  ansible.builtin.set_fact:
     github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}"
   when: runner_org | bool
 
 - name: Register runner
-  command:
+  ansible.builtin.command:
     "{{ runner_dir }}/./config.sh \
     --url {{ github_full_url }} \
     --token {{ registration.json.token }} \
@@ -109,7 +105,7 @@
   when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
 
 - name: Replace registered runner
-  command:
+  ansible.builtin.command:
     "{{ runner_dir }}/config.sh \
     --url {{ github_full_url }} \
     --token {{ registration.json.token }} \
@@ -126,18 +122,18 @@
   when: runner_name in registered_runners.json.runners|map(attribute='name')|list and reinstall_runner and not runner_org
 
 - name: Install service
-  command: "./svc.sh install {{ runner_user }}"
+  ansible.builtin.command: "./svc.sh install {{ runner_user }}"
   args:
     chdir: "{{ runner_dir }}"
   when: not runner_service_file_path.stat.exists
 
 - name: Read service name from file
-  slurp:
+  ansible.builtin.slurp:
     src: "{{ runner_dir }}/.service"
   register: runner_service
 
 - name: START and enable Github Actions Runner service
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ runner_service.content | b64decode | replace('\n', '') }}"
     state: started
     enabled: yes
@@ -145,7 +141,7 @@
   when: runner_state|lower == "started"
 
 - name: STOP and disable Github Actions Runner service
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ runner_service.content | b64decode | replace('\n', '') }}"
     state: stopped
     enabled: no
@@ -153,7 +149,7 @@
   when: runner_state|lower == "stopped"
 
 - name: Version changed - RESTART Github Actions Runner service
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ runner_service.content | b64decode | replace('\n', '') }}"
     state: restarted
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,30 +1,30 @@
 ---
 - name: Include Assert tasks
-  include_tasks: assert.yml
+  ansible.builtin.include_tasks: assert.yml
   tags:
     - install
     - uninstall
 
 - name: Include Information collection taks
-  include_tasks: collect_info.yml
+  ansible.builtin.include_tasks: collect_info.yml
   tags:
     - install
     - uninstall
 
 - name: Include tasks to install dependencies
-  include_tasks: install_deps.yml
+  ansible.builtin.include_tasks: install_deps.yml
   when: runner_state|lower == "started" or runner_state|lower == "stopped"
   tags:
     - install
 
 - name: Include tasks to uninstall runner
-  include_tasks: uninstall_runner.yml
+  ansible.builtin.include_tasks: uninstall_runner.yml
   when: reinstall_runner or runner_state|lower == "absent"
   tags:
     - uninstall
 
 - name: Include tasks to install runner
-  include_tasks: install_runner.yml
+  ansible.builtin.include_tasks: install_runner.yml
   when: runner_state|lower == "started" or runner_state|lower == "stopped"
   tags:
     - install

--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -1,23 +1,23 @@
 ---
 - name: Check if runner service name file exist
-  stat:
+  ansible.builtin.stat:
     path: "{{ runner_dir }}/.service"
   register: runner_service_file_path
 
 - name: Uninstall runner
-  command: "./svc.sh uninstall"
+  ansible.builtin.command: "./svc.sh uninstall"
   args:
     chdir: "{{ runner_dir }}"
   become: yes
   when: runner_service_file_path.stat.exists
 
 - name: Check GitHub Actions runner file
-  stat:
+  ansible.builtin.stat:
     path: "{{ runner_dir }}/.runner"
   register: runner_file
 
 - name: Unregister runner from the GitHub
-  command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
+  ansible.builtin.command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
   args:
     chdir: "{{ runner_dir }}"
   become: yes
@@ -26,6 +26,6 @@
   when: runner_name in registered_runners.json.runners|map(attribute='name')|list and runner_file.stat.exists
 
 - name: Delete runner directory
-  file:
+  ansible.builtin.file:
     path: "{{ runner_dir }}"
     state: absent


### PR DESCRIPTION
# Description

- Download GHA Runner package directly to the runner node. Fixes #142 
- Variable `runner_pkg_tempdir` has been removed
- Use FQCN for Ansible modules

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested with Molecule
