### PR TITLE
[fix]: enable root run & refactor ansible role

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -4,7 +4,7 @@
     that:
       - github_account is defined
     fail_msg: "github_account is not defined"
-  run_once: yes
+  run_once: true
 
 - name: Check access_token variable (RUN ONCE)
   ansible.builtin.assert:
@@ -12,11 +12,11 @@
       - access_token is defined
       - access_token | length > 0
     fail_msg: "access_token was not found or is using an invalid format."
-  run_once: yes
+  run_once: true
 
 - name: Check runner_org variable (RUN ONCE)
   ansible.builtin.assert:
     that:
       - runner_org | bool == True or runner_org == False
     fail_msg: "runner_org should be a boolean value"
-  run_once: yes
+  run_once: true

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -20,7 +20,7 @@
       status_code: 201
       force_basic_auth: yes
     register: registration
-    run_once: yes
+    run_once: true
 
   - name: Check currently registered runners for repo (RUN ONCE)
     ansible.builtin.uri:
@@ -32,7 +32,7 @@
       status_code: 200
       force_basic_auth: yes
     register: registered_runners
-    run_once: yes
+    run_once: true
 
   - name: Check service facts
     ansible.builtin.service_facts:

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -17,7 +17,7 @@
     body_format: json
   check_mode: false
   register: api_response
-  run_once: yes
+  run_once: true
   become: false
   delegate_to: localhost
   when: runner_version == "latest"
@@ -31,34 +31,18 @@
   ansible.builtin.command: "grep -i {{ runner_version }} {{ runner_dir }}/bin/Runner.Listener.deps.json"
   register: runner_installed
   check_mode: false
-  changed_when: False
-  ignore_errors: yes
+  changed_when: false
+  ignore_errors: true
 
-- name: Create temporary directory for archive
-  ansible.builtin.tempfile:
-    state: directory
-    suffix: runner
-  become: false
-  register: temp_dir
-  when: runner_version not in runner_installed.stdout
-
-- name: Download runner package version - "{{ runner_version }}" (RUN ONCE)
-  ansible.builtin.get_url:
-    url:
-      "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\
-      actions-runner-linux-{{ github_actions_architecture }}-{{ runner_version }}.tar.gz"
-    dest: "{{ temp_dir.path }}/actions-runner-linux-{{ runner_version }}.tar.gz"
-    force: no
-  become: false
-  when: runner_version not in runner_installed.stdout or reinstall_runner
-
-- name: Unarchive package
+- name: Unarchive runner package
   ansible.builtin.unarchive:
-    src: "{{ temp_dir.path }}/actions-runner-linux-{{ runner_version }}.tar.gz"
+    src: "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\
+          actions-runner-linux-{{ github_actions_architecture }}-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user }}"
     remote_src: yes
     mode: 0755
+  become: true
   when: runner_version not in runner_installed.stdout or reinstall_runner
 
 - name: Configure custom env file if required
@@ -88,6 +72,8 @@
   when: runner_org | bool
 
 - name: Register runner
+  environment:
+    RUNNER_ALLOW_RUNASROOT: "1"
   ansible.builtin.command:
     "{{ runner_dir }}/./config.sh \
     --url {{ github_full_url }} \
@@ -99,12 +85,14 @@
     {{ runner_extra_config_args }}"
   args:
     chdir: "{{ runner_dir }}"
-  become: yes
+  become: true
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
 
 - name: Replace registered runner
+  environment:
+    RUNNER_ALLOW_RUNASROOT: "1"
   ansible.builtin.command:
     "{{ runner_dir }}/config.sh \
     --url {{ github_full_url }} \
@@ -116,7 +104,7 @@
     --replace"
   args:
     chdir: "{{ runner_dir }}"
-  become: yes
+  become: true
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name in registered_runners.json.runners|map(attribute='name')|list and reinstall_runner and not runner_org

--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -8,7 +8,7 @@
   ansible.builtin.command: "./svc.sh uninstall"
   args:
     chdir: "{{ runner_dir }}"
-  become: yes
+  become: true
   when: runner_service_file_path.stat.exists
 
 - name: Check GitHub Actions runner file
@@ -17,10 +17,12 @@
   register: runner_file
 
 - name: Unregister runner from the GitHub
+  environment:
+    RUNNER_ALLOW_RUNASROOT: "1"
   ansible.builtin.command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
   args:
     chdir: "{{ runner_dir }}"
-  become: yes
+  become: true
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name in registered_runners.json.runners|map(attribute='name')|list and runner_file.stat.exists


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

# Description
1. I see a problem in the `install_runner` and `uninstall_runner` tasks: `./config.sh` script is not allowed to be run by root user it gives the following error output while running this playbook: `Must not run with sudo`. To avoid this problem, I suggest to add the `RUNNER_ALLOW_RUNASROOT: "1" environment variable to the particular Ansible tasks.
2. Reduce a not necessary steps to create a temporal directory and download the `github-actions` archive into it.
3. Update some of Ansible syntax statements.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)
