### PR TITLE
Set the right group permissions.

### DIFF
--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -37,4 +37,9 @@
   - name: Check service facts
     ansible.builtin.service_facts:
 
+  - name: Get Runner User IDs
+    ansible.builtin.getent:
+      database: passwd
+      key: "{{ runner_user }}"
+
   check_mode: false

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -4,7 +4,8 @@
     path: "{{ runner_dir }}"
     state: directory
     mode: 0755
-    owner: "{{ runner_user }}"
+    owner: "{{ ansible_facts.getent_passwd[runner_user].1 }}"
+    group: "{{ ansible_facts.getent_passwd[runner_user].2 }}"
 
 - name: Find the latest runner version (RUN ONCE)
   ansible.builtin.uri:
@@ -39,7 +40,8 @@
     src: "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\
           actions-runner-linux-{{ github_actions_architecture }}-{{ runner_version }}.tar.gz"
     dest: "{{ runner_dir }}/"
-    owner: "{{ runner_user }}"
+    owner: "{{ ansible_facts.getent_passwd[runner_user].1 }}"
+    group: "{{ ansible_facts.getent_passwd[runner_user].2 }}"
     remote_src: yes
     mode: 0755
   become: true


### PR DESCRIPTION
The files and folders in runner_dir should have the same group permissions as runner_user.

# Description

This is not an issue with the role itself, rather than the `unarchive` module (I think), which seem to set the incorrect group on files/folders after the extraction. I figured the group could be set on the created folder and the unarchived files to keep the permissions correct. 

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

I tested this manually against the test server.