### PR TITLE
Assert github_repo exists in runners for a repo

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -20,3 +20,12 @@
       - runner_org | bool == True or runner_org == False
     fail_msg: "runner_org should be a boolean value"
   run_once: true
+
+- name: Check github_repo variable (RUN ONCE)
+  ansible.builtin.assert:
+    that:
+      - github_repo is defined
+      - github_repo | length > 0
+    fail_msg: "github_repo was not found or is using an invalid format."
+  run_once: true
+  when: not runner_org


### PR DESCRIPTION
# Description

<!---
github_repo is needed if the user wishes to create an Action Runner for a repository. Therefore adding this check to fail fast in case the var is missing.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

<!---
There was no need, this is just a check
--->
