### PR TITLE
Add possibility to install runner as docker containers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ runner_extra_config_args: ""
 
 # Name to assign to this runner in GitHub (System hostname as default)
 runner_name: "{{ ansible_hostname }}"
+
 # GitHub Repository user or Organization owner used for Runner registration
 # github_account: "youruser"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,6 @@ runner_extra_config_args: ""
 
 # Name to assign to this runner in GitHub (System hostname as default)
 runner_name: "{{ ansible_hostname }}"
-
 # GitHub Repository user or Organization owner used for Runner registration
 # github_account: "youruser"
 
@@ -74,3 +73,5 @@ runner_name: "{{ ansible_hostname }}"
 #   restart_policy: "always"
 #   ephemeral: "false"
 #   workdir: /tmp/runner
+# runner_image_docker_host_gid: 1002
+# runner_image_docker_compose_version: 1.29.2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,3 +62,15 @@ runner_name: "{{ ansible_hostname }}"
 # https_proxy=YOUR_URL_HERE
 # no_proxy=localhost,127.0.0.1,127.0.0.2
 # HTTP_PROXY=
+
+# Whether to install the runner as service or as docker container
+install_as_service: true
+
+# The name of the docker image to build
+runner_docker_settings:
+  image_name: actions-runner-{{ runner_system }}-{{ github_actions_architecture }}-{{ runner_version }}
+  memory: "16g"
+  cpus: "3"
+  restart_policy: "always"
+  ephemeral: "false"
+  workdir: /tmp/runner

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,6 @@ runner_extra_config_args: ""
 
 # Name to assign to this runner in GitHub (System hostname as default)
 runner_name: "{{ ansible_hostname }}"
-
 # GitHub Repository user or Organization owner used for Runner registration
 # github_account: "youruser"
 
@@ -64,13 +63,13 @@ runner_name: "{{ ansible_hostname }}"
 # HTTP_PROXY=
 
 # Whether to install the runner as service or as docker container
-install_as_service: true
+# install_as_service: true
 
-# The name of the docker image to build
-runner_docker_settings:
-  image_name: actions-runner-{{ runner_system }}-{{ github_actions_architecture }}-{{ runner_version }}
-  memory: "16g"
-  cpus: "3"
-  restart_policy: "always"
-  ephemeral: "false"
-  workdir: /tmp/runner
+# Docker settings
+# runner_docker_settings:
+#   image_name: actions-runner-{{ runner_system }}-{{ github_actions_architecture }}-{{ runner_version }}
+#   memory: "16g"
+#   cpus: "3"
+#   restart_policy: "always"
+#   ephemeral: "false"
+#   workdir: /tmp/runner

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -1,0 +1,15 @@
+ARG RUNNER_VERSION
+FROM myoung34/github-runner:${RUNNER_VERSION}
+
+RUN rm /usr/local/bin/docker-compose && \
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \ 
+    sudo chmod +x /usr/local/bin/docker-compose
+
+# create the default user
+RUN groupadd -r -g 1000 gitrunner \
+    && useradd -m -d /home/gitrunner -G sudo -s /bin/bash -u 1000 -g 1000 gitrunner \
+    && chown -R 1000:1000 /actions-runner \
+    && groupadd -g 130 docker-host \
+    && usermod -aG docker-host gitrunner
+
+USER gitrunner

--- a/files/Dockerfile
+++ b/files/Dockerfile
@@ -1,15 +1,18 @@
 ARG RUNNER_VERSION
 FROM myoung34/github-runner:${RUNNER_VERSION}
 
+ARG DOCKER_HOST_GID=1002
+ARG DOCKER_COMPOSE_VERSION=1.29.2
+
 RUN rm /usr/local/bin/docker-compose && \
-    sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \ 
+    sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \ 
     sudo chmod +x /usr/local/bin/docker-compose
 
 # create the default user
 RUN groupadd -r -g 1000 gitrunner \
     && useradd -m -d /home/gitrunner -G sudo -s /bin/bash -u 1000 -g 1000 gitrunner \
     && chown -R 1000:1000 /actions-runner \
-    && groupadd -g 130 docker-host \
+    && groupadd -g ${DOCKER_HOST_GID} docker-host \
     && usermod -aG docker-host gitrunner
 
 USER gitrunner

--- a/files/runner.env.j2
+++ b/files/runner.env.j2
@@ -1,0 +1,23 @@
+# see https://github.com/myoung34/docker-github-actions-runner#environment-variables for more details on env vars of the docker image
+#ACCESS_TOKEN
+#APP_ID
+#APP_LOGIN
+#APP_PRIVATE_KEY
+#CONFIGURED_ACTIONS_RUNNER_FILES_DIR
+#DISABLE_AUTO_UPDATE
+#DISABLE_AUTOMATIC_DEREGISTRATION
+#ENTERPRISE_NAME
+#GITHUB_HOST
+EPHEMERAL={{ runner_docker_settings.ephemeral }}
+LABELS={{ runner_labels | join(',') }}
+ORG_NAME={{github_owner}}
+RANDOM_RUNNER_SUFFIX=random
+REPO_URL={{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo | default() }}/repo
+RUN_AS_ROOT=false
+RUNNER_GROUP={{runner_group}}
+RUNNER_NAME={{runner_name}}
+#RUNNER_NAME_PREFIX
+RUNNER_SCOPE={{ 'org' if runner_org == 'yes' else 'repo' }}
+RUNNER_TOKEN={{ registration.json.token }}
+RUNNER_WORKDIR={{runner_docker_settings.workdir}}
+# START_DOCKER_SERVICE

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -12,135 +12,187 @@
     runner_version: "{{ api_response.json.tag_name | regex_replace('^v', '') }}"
   when: runner_version == "latest"
 
-- name: Check if desired version already installed
-  ansible.builtin.command: "grep -i {{ runner_version }} {{ runner_dir }}/bin/Runner.Listener.deps.json"
-  register: runner_installed
-  check_mode: false
-  changed_when: false
-  ignore_errors: true
+- name: Install, update and configure runner via service
+  block:
+    - name: Check if desired version already installed
+      ansible.builtin.command: "grep -i {{ runner_version }} {{ runner_dir }}/bin/Runner.Listener.deps.json"
+      register: runner_installed
+      check_mode: false
+      changed_when: false
+      ignore_errors: true
 
-- name: Unarchive runner package
-  ansible.builtin.unarchive:
-    src: "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\
+    - name: Unarchive runner package
+      ansible.builtin.unarchive:
+        src:
+          "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\
           actions-runner-{{ runner_system }}-{{ github_actions_architecture }}-{{ runner_version }}.tar.gz"
-    dest: "{{ runner_dir }}/"
-    owner: "{{ runner_user_id.stdout }}"
-    group: "{{ runner_user_group_id.stdout }}"
-    remote_src: yes
-    mode: 0755
-  environment:
-    PATH: /usr/local/bin:/opt/homebrew/bin/:{{ ansible_env.HOME }}/bin:{{ ansible_env.PATH }}
-  when: runner_version not in runner_installed.stdout or reinstall_runner
+        dest: "{{ runner_dir }}/"
+        owner: "{{ runner_user_id.stdout }}"
+        group: "{{ runner_user_group_id.stdout }}"
+        remote_src: yes
+        mode: 0755
+      environment:
+        PATH: /usr/local/bin:/opt/homebrew/bin/:{{ ansible_env.HOME }}/bin:{{ ansible_env.PATH }}
+      when: runner_version not in runner_installed.stdout or reinstall_runner
 
-- name: Configure custom env file if required
-  ansible.builtin.blockinfile:
-    path: "{{ runner_dir }}/.env"
-    block: "{{ custom_env }}"
-    owner: "{{ runner_user }}"
-    create: yes
-    mode: 0755
-    marker_begin: "# BEGIN ANSIBLE MANAGED BLOCK"
-    marker_end: "# END ANSIBLE MANAGED BLOCK"
-  when: custom_env is defined
+    - name: Configure custom env file if required
+      ansible.builtin.blockinfile:
+        path: "{{ runner_dir }}/.env"
+        block: "{{ custom_env }}"
+        owner: "{{ runner_user }}"
+        create: yes
+        mode: 0755
+        marker_begin: "# BEGIN ANSIBLE MANAGED BLOCK"
+        marker_end: "# END ANSIBLE MANAGED BLOCK"
+      when: custom_env is defined
 
-- name: Check if runner service name file exist
-  ansible.builtin.stat:
-    path: "{{ runner_dir }}/.service"
-  register: runner_service_file_path
+    - name: Check if runner service name file exist
+      ansible.builtin.stat:
+        path: "{{ runner_dir }}/.service"
+      register: runner_service_file_path
 
-- name: Set complete GitHub url for repo runner
-  ansible.builtin.set_fact:
-    github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo }}"
-  when: not runner_org
+    - name: Set complete GitHub url for repo runner
+      ansible.builtin.set_fact:
+        github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo }}"
+      when: not runner_org
 
-- name: Set complete GitHub url for org runner
-  ansible.builtin.set_fact:
-    github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}"
-  when: runner_org | bool
+    - name: Set complete GitHub url for org runner
+      ansible.builtin.set_fact:
+        github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}"
+      when: runner_org | bool
 
-- name: Register runner
-  environment:
-    RUNNER_ALLOW_RUNASROOT: "1"
-  ansible.builtin.command:
-    "{{ runner_dir }}/./config.sh \
-    --url {{ github_full_url }} \
-    --token {{ registration.json.token }} \
-    --name '{{ runner_name }}' \
-    --labels {{ runner_labels | join(',') }} \
-    --runnergroup {{ runner_group }} \
-    --unattended \
-    {{ runner_extra_config_args }}"
-  args:
-    chdir: "{{ runner_dir }}"
-  become_user: "{{ runner_user }}"
-  no_log: "{{ hide_sensitive_logs | bool }}"
-  when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
+    - name: Register runner
+      environment:
+        RUNNER_ALLOW_RUNASROOT: "1"
+      ansible.builtin.command: "{{ runner_dir }}/./config.sh \
+        --url {{ github_full_url }} \
+        --token {{ registration.json.token }} \
+        --name '{{ runner_name }}' \
+        --labels {{ runner_labels | join(',') }} \
+        --runnergroup {{ runner_group }} \
+        --unattended \
+        {{ runner_extra_config_args }}"
+      args:
+        chdir: "{{ runner_dir }}"
+      become_user: "{{ runner_user }}"
+      no_log: "{{ hide_sensitive_logs | bool }}"
+      when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
 
-- name: Replace registered runner
-  environment:
-    RUNNER_ALLOW_RUNASROOT: "1"
-  ansible.builtin.command:
-    "{{ runner_dir }}/config.sh \
-    --url {{ github_full_url }} \
-    --token {{ registration.json.token }} \
-    --name '{{ runner_name }}' \
-    --labels {{ runner_labels | join(',') }} \
-    --unattended \
-    {{ runner_extra_config_args }} \
-    --replace"
-  args:
-    chdir: "{{ runner_dir }}"
-  become_user: "{{ runner_user }}"
-  no_log: "{{ hide_sensitive_logs | bool }}"
-  when: runner_name in registered_runners.json.runners|map(attribute='name')|list and reinstall_runner and not runner_org
+    - name: Replace registered runner
+      environment:
+        RUNNER_ALLOW_RUNASROOT: "1"
+      ansible.builtin.command: "{{ runner_dir }}/config.sh \
+        --url {{ github_full_url }} \
+        --token {{ registration.json.token }} \
+        --name '{{ runner_name }}' \
+        --labels {{ runner_labels | join(',') }} \
+        --unattended \
+        {{ runner_extra_config_args }} \
+        --replace"
+      args:
+        chdir: "{{ runner_dir }}"
+      become_user: "{{ runner_user }}"
+      no_log: "{{ hide_sensitive_logs | bool }}"
+      when: runner_name in registered_runners.json.runners|map(attribute='name')|list and reinstall_runner and not runner_org
 
-- name: Install service
-  ansible.builtin.command: "./svc.sh install {{ runner_user }}"
-  args:
-    chdir: "{{ runner_dir }}"
-  become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
-  when: not runner_service_file_path.stat.exists
+    - name: Install service
+      ansible.builtin.command: "./svc.sh install {{ runner_user }}"
+      args:
+        chdir: "{{ runner_dir }}"
+      become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
+      when: not runner_service_file_path.stat.exists
 
-- name: Read service name from file
-  ansible.builtin.slurp:
-    src: "{{ runner_dir }}/.service"
-  register: runner_service
+    - name: Read service name from file
+      ansible.builtin.slurp:
+        src: "{{ runner_dir }}/.service"
+      register: runner_service
 
-- name: START and enable Github Actions Runner service (Linux)
-  ansible.builtin.command: "./svc.sh start"
-  args:
-    chdir: "{{ runner_dir }}"
-  no_log: "{{ hide_sensitive_logs | bool }}"
-  ignore_errors: "{{ ansible_check_mode }}"
-  when: ansible_system != 'Darwin' and runner_state|lower == "started" and ansible_facts.services[(runner_service.content | b64decode) | trim ]['state'] != 'running'
+    - name: START and enable Github Actions Runner service (Linux)
+      ansible.builtin.command: "./svc.sh start"
+      args:
+        chdir: "{{ runner_dir }}"
+      no_log: "{{ hide_sensitive_logs | bool }}"
+      ignore_errors: "{{ ansible_check_mode }}"
+      when: ansible_system != 'Darwin' and runner_state|lower == "started" and ansible_facts.services[(runner_service.content | b64decode) | trim ]['state'] != 'running'
 
-- name: START and enable Github Actions Runner service (macOS) # TODO: Idempotence
-  ansible.builtin.command: "./svc.sh start"
-  args:
-    chdir: "{{ runner_dir }}"
-  become: false
-  no_log: "{{ hide_sensitive_logs | bool }}"
-  ignore_errors: "{{ ansible_check_mode }}"
-  when: ansible_system == 'Darwin' and runner_state|lower
+    - name: START and enable Github Actions Runner service (macOS) # TODO: Idempotence
+      ansible.builtin.command: "./svc.sh start"
+      args:
+        chdir: "{{ runner_dir }}"
+      become: false
+      no_log: "{{ hide_sensitive_logs | bool }}"
+      ignore_errors: "{{ ansible_check_mode }}"
+      when: ansible_system == 'Darwin' and runner_state|lower
 
-- name: STOP and disable Github Actions Runner service
-  ansible.builtin.shell: "./svc.sh stop"
-  args:
-    chdir: "{{ runner_dir }}"
-  become: "{{ 'false' if ansible_distribution == 'MacOS' else 'true' }}"
-  no_log: "{{ hide_sensitive_logs | bool }}"
-  ignore_errors: "{{ ansible_check_mode }}"
-  when: runner_state|lower == "stopped"
+    - name: STOP and disable Github Actions Runner service
+      ansible.builtin.shell: "./svc.sh stop"
+      args:
+        chdir: "{{ runner_dir }}"
+      become: "{{ 'false' if ansible_distribution == 'MacOS' else 'true' }}"
+      no_log: "{{ hide_sensitive_logs | bool }}"
+      ignore_errors: "{{ ansible_check_mode }}"
+      when: runner_state|lower == "stopped"
 
-- name: Version changed - RESTART Github Actions Runner service
-  ansible.builtin.shell:
-    cmd: |
-      ./svc.sh stop
-      sleep 5
-      ./svc.sh start
-  args:
-    chdir: "{{ runner_dir }}"
-  become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
-  no_log: "{{ hide_sensitive_logs | bool }}"
-  ignore_errors: "{{ ansible_check_mode }}"
-  when: runner_version not in runner_installed.stdout and not runner_state|lower == "stopped"
+    - name: Version changed - RESTART Github Actions Runner service
+      ansible.builtin.shell:
+        cmd: |
+          ./svc.sh stop
+          sleep 5
+          ./svc.sh start
+      args:
+        chdir: "{{ runner_dir }}"
+      become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
+      no_log: "{{ hide_sensitive_logs | bool }}"
+      ignore_errors: "{{ ansible_check_mode }}"
+      when: runner_version not in runner_installed.stdout and not runner_state|lower == "stopped"
+  when: install_as_service is true
+
+- name: Install as docker container
+  block:
+    - name: Copy files
+      ansible.builtin.copy:
+        src: "files/{{ item }}"
+        dest: "{{ runner_dir }}"
+        mode: 0755
+        owner: "{{ runner_user_id.stdout }}"
+        group: "{{ runner_user_group_id.stdout }}"
+      with_items:
+        - Dockerfile
+
+    - name: Build docker image
+      docker_image:
+        name: runner_docker_settings.image_name
+        build:
+          pull: no
+          args:
+            RUNNER_VERSION: "{{ runner_version }}"
+          path: "{{ runner_dir }}"
+        force_source: yes
+        source: build
+
+    - name: Create a container from the built image
+      community.docker.docker_container:
+        name: "{{ runner_name }}"
+        image: runner_docker_settings.image_name
+        state: started
+        init: yes
+        memory: "{{ runner_docker_settings.memory | string }}"
+        cpus: "{{ runner_docker_settings.cpus | string }}"
+        recreate: yes
+        restart_policy: "{{ runner_docker_settings.restart_policy | string }}"
+        env:
+          # see https://github.com/myoung34/docker-github-actions-runner for more details on env vars of the docker image
+          RUNNER_TOKEN: "{{ registration.json.token }}"
+          # CONFIGURED_ACTIONS_RUNNER_FILES_DIR: "{{ runner_docker_settings.workdir }}/.runner_config"
+          EPHEMERAL: "{{ runner_docker_settings.ephemeral }}"
+          LABELS: "{{ runner_labels | join(',') }}"
+          ORG_NAME: "{{github_owner}}"
+          RANDOM_RUNNER_SUFFIX: random
+          REPO_URL: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo | default() }}/repo"
+          RUNNER_GROUP: "{{runner_group}}"
+          RUNNER_NAME: "{{runner_name}}"
+          RUNNER_WORKDIR: "{{runner_docker_settings.workdir}}"
+          RUN_AS_ROOT: "false"
+          RUNNER_SCOPE: "{{ 'org' if runner_org == 'yes' else 'repo' }}"
+
+  when: install_as_service is false

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -182,16 +182,16 @@
         restart_policy: "{{ runner_docker_settings.restart_policy | string }}"
         env:
           # see https://github.com/myoung34/docker-github-actions-runner for more details on env vars of the docker image
-          RUNNER_TOKEN: "{{ registration.json.token }}"
           EPHEMERAL: "{{ runner_docker_settings.ephemeral }}"
           LABELS: "{{ runner_labels | join(',') }}"
           ORG_NAME: "{{github_owner}}"
           RANDOM_RUNNER_SUFFIX: random
           REPO_URL: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo | default() }}/repo"
+          RUN_AS_ROOT: "false"
           RUNNER_GROUP: "{{runner_group}}"
           RUNNER_NAME: "{{runner_name}}"
-          RUNNER_WORKDIR: "{{runner_docker_settings.workdir}}"
-          RUN_AS_ROOT: "false"
           RUNNER_SCOPE: "{{ 'org' if runner_org == 'yes' else 'repo' }}"
+          RUNNER_TOKEN: "{{ registration.json.token }}"
+          RUNNER_WORKDIR: "{{runner_docker_settings.workdir}}"
 
   when: install_as_service is false

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -149,15 +149,21 @@
 
 - name: Install as docker container
   block:
-    - name: Copy files
+    - name: Copy Dockerfile
       ansible.builtin.copy:
-        src: "files/{{ item }}"
+        src: "files/Dockerfile"
         dest: "{{ runner_dir }}"
         mode: 0755
         owner: "{{ runner_user_id.stdout }}"
         group: "{{ runner_user_group_id.stdout }}"
-      with_items:
-        - Dockerfile
+
+    - name: Deploy env file with templating
+      template:
+        src: "files/runner.env.j2"
+        dest: "{{ runner_dir }}/{{ runner_name }}.env"
+        mode: 0755
+        owner: "{{ runner_user_id.stdout }}"
+        group: "{{ runner_user_group_id.stdout }}"
 
     - name: Build docker image
       docker_image:
@@ -180,18 +186,6 @@
         cpus: "{{ runner_docker_settings.cpus | string }}"
         recreate: yes
         restart_policy: "{{ runner_docker_settings.restart_policy | string }}"
-        env:
-          # see https://github.com/myoung34/docker-github-actions-runner for more details on env vars of the docker image
-          EPHEMERAL: "{{ runner_docker_settings.ephemeral }}"
-          LABELS: "{{ runner_labels | join(',') }}"
-          ORG_NAME: "{{github_owner}}"
-          RANDOM_RUNNER_SUFFIX: random
-          REPO_URL: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo | default() }}/repo"
-          RUN_AS_ROOT: "false"
-          RUNNER_GROUP: "{{runner_group}}"
-          RUNNER_NAME: "{{runner_name}}"
-          RUNNER_SCOPE: "{{ 'org' if runner_org == 'yes' else 'repo' }}"
-          RUNNER_TOKEN: "{{ registration.json.token }}"
-          RUNNER_WORKDIR: "{{runner_docker_settings.workdir}}"
+        env_file: "{{ runner_dir }}/{{ runner_name }}.env"
 
   when: install_as_service is false

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -167,11 +167,13 @@
 
     - name: Build docker image
       docker_image:
-        name: runner_docker_settings.image_name
+        name: "{{ runner_docker_settings.image_name }}"
         build:
           pull: no
           args:
             RUNNER_VERSION: "{{ runner_version }}"
+            DOCKER_HOST_GID: "{{ runner_image_docker_host_gid }}"
+            DOCKER_COMPOSE_VERSION: "{{ runner_image_docker_compose_version }}"
           path: "{{ runner_dir }}"
         force_source: yes
         source: build
@@ -179,7 +181,7 @@
     - name: Create a container from the built image
       community.docker.docker_container:
         name: "{{ runner_name }}"
-        image: runner_docker_settings.image_name
+        image: "{{ runner_docker_settings.image_name }}"
         state: started
         init: yes
         memory: "{{ runner_docker_settings.memory | string }}"
@@ -187,5 +189,7 @@
         recreate: yes
         restart_policy: "{{ runner_docker_settings.restart_policy | string }}"
         env_file: "{{ runner_dir }}/{{ runner_name }}.env"
+        volumes:
+          - "/var/run/docker.sock:/var/run/docker.sock"
 
   when: install_as_service is false

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -183,7 +183,6 @@
         env:
           # see https://github.com/myoung34/docker-github-actions-runner for more details on env vars of the docker image
           RUNNER_TOKEN: "{{ registration.json.token }}"
-          # CONFIGURED_ACTIONS_RUNNER_FILES_DIR: "{{ runner_docker_settings.workdir }}/.runner_config"
           EPHEMERAL: "{{ runner_docker_settings.ephemeral }}"
           LABELS: "{{ runner_labels | join(',') }}"
           ORG_NAME: "{{github_owner}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Include tasks to install dependencies
   ansible.builtin.include_tasks: install_deps.yml
-  when: runner_state|lower == "started" or runner_state|lower == "stopped"
+  when: (runner_state|lower == "started" or runner_state|lower == "stopped") and install_as_service is true
   tags:
     - install
 

--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -1,33 +1,54 @@
 ---
-- name: Check if runner service name file exist
-  ansible.builtin.stat:
-    path: "{{ runner_dir }}/.service"
-  register: runner_service_file_path
+- name: Uninstall runner as service
+  block:
+    - name: Check if runner service name file exist
+      ansible.builtin.stat:
+        path: "{{ runner_dir }}/.service"
+      register: runner_service_file_path
 
-- name: Uninstall runner
-  ansible.builtin.command: "./svc.sh uninstall"
-  args:
-    chdir: "{{ runner_dir }}"
-  become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
-  when: runner_service_file_path.stat.exists
+    - name: Uninstall runner
+      ansible.builtin.command: "./svc.sh uninstall"
+      args:
+        chdir: "{{ runner_dir }}"
+      become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
+      when: runner_service_file_path.stat.exists
 
-- name: Check GitHub Actions runner file
-  ansible.builtin.stat:
-    path: "{{ runner_dir }}/.runner"
-  register: runner_file
+    - name: Check GitHub Actions runner file
+      ansible.builtin.stat:
+        path: "{{ runner_dir }}/.runner"
+      register: runner_file
 
-- name: Unregister runner from the GitHub
-  environment:
-    RUNNER_ALLOW_RUNASROOT: "1"
-  ansible.builtin.command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
-  args:
-    chdir: "{{ runner_dir }}"
-  become: false
-  become_user: "{{ runner_user }}"
-  no_log: "{{ hide_sensitive_logs | bool }}"
-  when: runner_name in registered_runners.json.runners|map(attribute='name')|list and runner_file.stat.exists
+    - name: Unregister runner from the GitHub
+      environment:
+        RUNNER_ALLOW_RUNASROOT: "1"
+      ansible.builtin.command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
+      args:
+        chdir: "{{ runner_dir }}"
+      become: false
+      become_user: "{{ runner_user }}"
+      no_log: "{{ hide_sensitive_logs | bool }}"
+      when: runner_name in registered_runners.json.runners|map(attribute='name')|list and runner_file.stat.exists
 
-- name: Delete runner directory
-  ansible.builtin.file:
-    path: "{{ runner_dir }}"
-    state: absent
+    - name: Delete runner directory
+      ansible.builtin.file:
+        path: "{{ runner_dir }}"
+        state: absent
+  when: install_as_service is true
+
+- name: Uninstall docker container
+  block:
+    - name: Check if container exist
+      community.docker.docker_container_info:
+        name: "{{ runner_name }}"
+      register: result
+
+    - name: Does container exist?
+      debug:
+        msg: "The container {{ 'exists' if result.exists else 'does not exist' }}"
+
+    - name: Delete runner directory
+      community.docker.docker_container:
+        name: "{{ runner_name }}"
+        state: absent
+      when: result.exists
+  when: install_as_service is false


### PR DESCRIPTION
# Description

This PR add the support to deploy the runner not only as a service, but also by means of a docker container. It leverages the image provided by https://github.com/myoung34/docker-github-actions-runner and adds some instructions to pull the image and create a container based on a specific version of the runner.
All the logic of registration/deregistration is already handled by the image

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

The changes have been tested by running local deployments and registering/deregistering runners for both repo level and org level runners. Tried running the molecule tests but not able to have the runners register in my private profile.
I gladly can extend also the tests, but will need some direction on how to do so. 
