### PR TITLE
support for enterprise self-hosted runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
         - master
+        - main
     types: [opened, synchronize, reopened]
     paths:
       - 'defaults/**'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.0.1
-      hooks:
-        - id: check-yaml
-          args: [--allow-multiple-documents]
-        - id: end-of-file-fixer
-        - id: trailing-whitespace
-          args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
 
-    - repo: https://github.com/adrienverge/yamllint
-      rev: v1.26.3
-      hooks:
-        - id: yamllint
-          args: [-c=.yamllint]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+        args: [-c=.yamllint]
 
-    - repo: https://github.com/robertdebock/pre-commit
-      rev: v1.2.3
-      hooks:
-        - id: ansible_role_find_unused_variable
-        - id: ansible_role_find_empty_files
-        - id: ansible_role_find_empty_directories
-        - id: ansible_role_fix_readability
+  - repo: https://github.com/robertdebock/pre-commit
+    rev: v1.2.3
+    hooks:
+      - id: ansible_role_find_unused_variable
+      - id: ansible_role_find_empty_files
+      - id: ansible_role_find_empty_directories
+      - id: ansible_role_fix_readability

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 
 This role will deploy/redeploy/uninstall and register/unregister local GitHub Actions Runner on Linux and macOS Systems (see [compatibility list](#supported-operating-systems) ).
-It supports both, Organization and Repository Runners.
+It supports Enterprise, Organization and Repository Runners.
 
 ## Requirements
 
@@ -18,7 +18,8 @@ It supports both, Organization and Repository Runners.
 * The role require Personal Access Token to access the GitHub. The token can be set as `PERSONAL_ACCESS_TOKEN` environment variable.
 
 > **Note**  
-> The token must have the `repo` scope (when creating a repo runner) or the `admin:org` scope (when creating a runner for an organization).
+> The token must have the `repo` scope (when creating a repo runner), the `admin:org` scope (when creating a runner for an organization),
+> the `manage_runners:enterprise` scope (when creating a enterprise runner).
 Personal Access Token for GitHub account can be created [here](https://github.com/settings/tokens).
 
 > **Warning**  
@@ -112,6 +113,9 @@ runner_name: "{{ ansible_hostname }}"
 # Github repository name
 # github_repo: "yourrepo"
 
+# GitHub Enterprise name
+# github_enterprise: "yourenterprise"
+
 # Configuring a custom .env file
 # custom_env: |
 # http_proxy=YOUR_URL_HERE
@@ -122,7 +126,7 @@ runner_name: "{{ ansible_hostname }}"
 # HTTP_PROXY=
 ```
 
-## Example Playbook
+## Example Playbooks
 
 In this example the Ansible role will install (or update) the GitHub Actions Runner service (latest available version). The runner will be registered for *my_awesome_repo* GitHub repo.
 Runner service will be stated and will run under the same user as the Ansible is using for ssh connection (*ansible*).
@@ -152,6 +156,20 @@ Same example as above, but runner will be added to an organization and deployed 
     - github_account: my_awesome_org
     - runner_org: yes
     - runner_on_ghes: yes
+  roles:
+    - role: monolithprojects.github_actions_runner
+```
+
+If you have a Github Enterprise Cloud license and you want to manage all the self-hosted runners from the enterprise:
+```yaml
+---
+- name: Install GitHub Actions Runner
+  hosts: all
+  user: automation
+  become: yes
+  vars:
+    - github_enterprise: my_awesome_enterprise
+    - runner_org: no
   roles:
     - role: monolithprojects.github_actions_runner
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,9 @@ runner_name: "{{ ansible_hostname }}"
 # Github repository name
 # github_repo: "yourrepo"
 
+# GitHub Enterprise name
+# github_enterprise: "yourenterprise"
+
 # Configuring a custom .env file
 # custom_env: |
 # http_proxy=YOUR_URL_HERE

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,10 +12,10 @@ runner_version: "latest"
 runner_state: "started"
 
 # If found on the server, delete already existing runner service and install it again
-reinstall_runner: no
+reinstall_runner: false
 
 # Do not show Ansible logs which may contain sensitive data (registration token)
-hide_sensitive_logs: yes
+hide_sensitive_logs: true
 
 # GitHub address
 github_url: "https://github.com"
@@ -27,7 +27,7 @@ github_api_url: "https://api.github.com"
 access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
 
 # Is it the runner for organization or not?
-runner_org: no
+runner_org: false
 
 # Labels to apply to the runner
 runner_labels: []

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -5,6 +5,7 @@
       - github_account is defined
     fail_msg: "github_account is not defined"
   run_once: true
+  when: not github_enterprise
 
 - name: Check access_token variable (RUN ONCE)
   ansible.builtin.assert:
@@ -20,6 +21,7 @@
       - runner_org | bool == True or runner_org == False
     fail_msg: "runner_org should be a boolean value"
   run_once: true
+  when: not github_enterprise
 
 - name: Check github_repo variable (RUN ONCE)
   ansible.builtin.assert:
@@ -28,4 +30,4 @@
       - github_repo | length > 0
     fail_msg: "github_repo was not found or is using an invalid format."
   run_once: true
-  when: not runner_org
+  when: not runner_org and not github_enterprise

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -5,17 +5,17 @@
   - name: Set complete API url for repo runner
     ansible.builtin.set_fact:
       github_full_api_url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
-    when: not runner_org and not runner_enterprise
+    when: not runner_org and not github_enterprise
 
   - name: Set complete API url for org runner
     ansible.builtin.set_fact:
       github_full_api_url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
-    when: runner_org | bool and not runner_enterprise
+    when: runner_org | bool and not github_enterprise
 
   - name: Set complete API url for enterprise runner
     ansible.builtin.set_fact:
       github_full_api_url: "{{ github_api_url }}/enterprises/{{ github_enterprise }}/actions/runners"
-    when: runner_enterprise
+    when: github_enterprise
 
   - name: Get registration token (RUN ONCE)
     ansible.builtin.uri:

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -5,12 +5,17 @@
   - name: Set complete API url for repo runner
     ansible.builtin.set_fact:
       github_full_api_url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
-    when: not runner_org
+    when: not runner_org and not runner_enterprise
 
   - name: Set complete API url for org runner
     ansible.builtin.set_fact:
       github_full_api_url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
-    when: runner_org | bool
+    when: runner_org | bool and not runner_enterprise
+
+  - name: Set complete API url for enterprise runner
+    ansible.builtin.set_fact:
+      github_full_api_url: "{{ github_api_url }}/enterprises/{{ github_enterprise }}/actions/runners"
+    when: runner_enterprise
 
   - name: Get registration token (RUN ONCE)
     ansible.builtin.uri:
@@ -24,7 +29,7 @@
     register: registration
     run_once: true
 
-  - name: Check currently registered runners for repo (RUN ONCE)
+  - name: Check currently registered runners (RUN ONCE)
     ansible.builtin.uri:
       url: "{{ github_full_api_url }}"
       headers:

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -2,76 +2,76 @@
 - name: Info collections
   check_mode: false
   block:
-  - name: Set complete API url for repo runner
-    ansible.builtin.set_fact:
-      github_full_api_url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
-    when: not runner_org and not github_enterprise
+    - name: Set complete API url for repo runner
+      ansible.builtin.set_fact:
+        github_full_api_url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
+      when: not runner_org and not github_enterprise
 
-  - name: Set complete API url for org runner
-    ansible.builtin.set_fact:
-      github_full_api_url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
-    when: runner_org | bool and not github_enterprise
+    - name: Set complete API url for org runner
+      ansible.builtin.set_fact:
+        github_full_api_url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
+      when: runner_org | bool and not github_enterprise
 
-  - name: Set complete API url for enterprise runner
-    ansible.builtin.set_fact:
-      github_full_api_url: "{{ github_api_url }}/enterprises/{{ github_enterprise }}/actions/runners"
-    when: github_enterprise
+    - name: Set complete API url for enterprise runner
+      ansible.builtin.set_fact:
+        github_full_api_url: "{{ github_api_url }}/enterprises/{{ github_enterprise }}/actions/runners"
+      when: github_enterprise
 
-  - name: Get registration token (RUN ONCE)
-    ansible.builtin.uri:
-      url: "{{ github_full_api_url }}/registration-token"
-      headers:
-        Authorization: "token {{ access_token }}"
-        Accept: "application/vnd.github.v3+json"
-      method: POST
-      status_code: 201
-      force_basic_auth: yes
-    register: registration
-    run_once: true
+    - name: Get registration token (RUN ONCE)
+      ansible.builtin.uri:
+        url: "{{ github_full_api_url }}/registration-token"
+        headers:
+          Authorization: "token {{ access_token }}"
+          Accept: "application/vnd.github.v3+json"
+        method: POST
+        status_code: 201
+        force_basic_auth: true
+      register: registration
+      run_once: true
 
-  - name: Check currently registered runners (RUN ONCE)
-    ansible.builtin.uri:
-      url: "{{ github_full_api_url }}"
-      headers:
-        Authorization: "token {{ access_token }}"
-        Accept: "application/vnd.github.v3+json"
-      method: GET
-      status_code: 200
-      force_basic_auth: yes
-    register: registered_runners
-    run_once: true
+    - name: Check currently registered runners (RUN ONCE)
+      ansible.builtin.uri:
+        url: "{{ github_full_api_url }}"
+        headers:
+          Authorization: "token {{ access_token }}"
+          Accept: "application/vnd.github.v3+json"
+        method: GET
+        status_code: 200
+        force_basic_auth: true
+      register: registered_runners
+      run_once: true
 
-  - name: Get Runner User IDs
-    ansible.builtin.command: id -u "{{ runner_user }}"
-    changed_when: false
-    register: runner_user_id
+    - name: Get Runner User IDs
+      ansible.builtin.command: id -u "{{ runner_user }}"
+      changed_when: false
+      register: runner_user_id
 
-  - name: Get Runner Group IDs
-    ansible.builtin.command: id -g "{{ runner_user }}"
-    changed_when: false
-    register: runner_user_group_id
+    - name: Get Runner Group IDs
+      ansible.builtin.command: id -g "{{ runner_user }}"
+      changed_when: false
+      register: runner_user_group_id
 
-  - name: Set runner_system variable
-    ansible.builtin.set_fact:
-      runner_system: "{{ 'osx' if ansible_system == 'Darwin' else 'linux' }}"
+    - name: Set runner_system variable
+      ansible.builtin.set_fact:
+        runner_system: "{{ 'osx' if ansible_system == 'Darwin' else 'linux' }}"
 
-  - name: Find the latest runner version (RUN ONCE)
-    ansible.builtin.uri:
-      url: "https://api.github.com/repos/{{ runner_download_repository }}/releases/latest"
-      headers:
-        Content-Type: "application/json"
-      method: GET
-      return_content: yes
-      status_code: 200
-      body_format: json
-    check_mode: false
-    register: api_response
-    run_once: true
-    become: false
-    delegate_to: localhost
-    when: runner_version == "latest"
+    - name: Find the latest runner version (RUN ONCE)
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ runner_download_repository }}/releases/latest"
+        headers:
+          Content-Type: "application/json"
+        method: GET
+        return_content: true
+        status_code: 200
+        body_format: json
+      check_mode: false
+      register: api_response
+      run_once: true
+      become: false
+      delegate_to: localhost
+      when: runner_version == "latest"
 
-  - name: Get systemd service facts
-    ansible.builtin.service_facts:
-    register: service_facts
-    when: ansible_system == "Linux"
+    - name: Get systemd service facts
+      ansible.builtin.service_facts:
+      register: service_facts
+      when: ansible_system == "Linux"

--- a/tasks/install_deps.yml
+++ b/tasks/install_deps.yml
@@ -10,7 +10,7 @@
       - libssl1.1
       - libicu57
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "9")
 
 - name: Install dependencies on Debian Buster
@@ -23,7 +23,7 @@
       - libssl1.1
       - libicu63
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
 
 - name: Install dependencies on Debian Bullseye
@@ -36,7 +36,7 @@
       - libssl1.1
       - libicu67
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "11")
 
 - name: Install dependencies on Debian Bookworm
@@ -49,7 +49,7 @@
       - libssl3
       - libicu72
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "12")
 
 - name: Install dependencies on Ubuntu Xenial systems
@@ -62,7 +62,7 @@
       - libssl1.0.0
       - libicu55
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16")
 
 - name: Install dependencies on Ubuntu Bionic systems
@@ -75,7 +75,7 @@
       - libssl1.1
       - libicu60
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18")
 
 - name: Install dependencies on Ubuntu Focal systems
@@ -88,7 +88,7 @@
       - libssl1.1
       - libicu66
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "20")
 
 - name: Install dependencies on Ubuntu Jammy systems
@@ -100,7 +100,7 @@
       - zlib1g
       - libicu70
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "22")
 
 - name: Install dependencies on RHEL/CentOS/Fedora systems
@@ -112,7 +112,7 @@
       - zlib
       - libicu
     state: present
-    update_cache: yes
+    update_cache: true
   when: (ansible_distribution == "RedHat") or
         (ansible_distribution == "CentOS") or
         (ansible_distribution == "Fedora") or

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: "{{ runner_dir }}"
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: "{{ runner_user_id.stdout }}"
     group: "{{ runner_user_group_id.stdout }}"
 
@@ -27,7 +27,7 @@
     owner: "{{ runner_user_id.stdout }}"
     group: "{{ runner_user_group_id.stdout }}"
     remote_src: yes
-    mode: 0755
+    mode: "0755"
   environment:
     PATH: /usr/local/bin:/opt/homebrew/bin/:{{ ansible_env.HOME }}/bin:{{ ansible_env.PATH }}
   when: runner_version not in runner_installed.stdout or reinstall_runner
@@ -38,7 +38,7 @@
     block: "{{ custom_env }}"
     owner: "{{ runner_user }}"
     create: yes
-    mode: 0755
+    mode: "0755"
     marker_begin: "# BEGIN ANSIBLE MANAGED BLOCK"
     marker_end: "# END ANSIBLE MANAGED BLOCK"
   when: custom_env is defined

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -51,17 +51,17 @@
 - name: Set complete GitHub url for repo runner
   ansible.builtin.set_fact:
     github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo }}"
-  when: not runner_org and not runner_enterprise
+  when: not runner_org and not github_enterprise
 
 - name: Set complete GitHub url for org runner
   ansible.builtin.set_fact:
     github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}"
-  when: runner_org | bool and not runner_enterprise
+  when: runner_org | bool and not github_enterprise
 
 - name: Set complete GitHub url for enterprise runner
   ansible.builtin.set_fact:
     github_full_url: "{{ github_url }}/enterprises/{{ github_enterprise }}"
-  when: runner_enterprise
+  when: github_enterprise
 
 - name: Register runner
   environment:

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -26,7 +26,7 @@
     dest: "{{ runner_dir }}/"
     owner: "{{ runner_user_id.stdout }}"
     group: "{{ runner_user_group_id.stdout }}"
-    remote_src: yes
+    remote_src: true
     mode: "0755"
   environment:
     PATH: /usr/local/bin:/opt/homebrew/bin/:{{ ansible_env.HOME }}/bin:{{ ansible_env.PATH }}
@@ -37,7 +37,7 @@
     path: "{{ runner_dir }}/.env"
     block: "{{ custom_env }}"
     owner: "{{ runner_user }}"
-    create: yes
+    create: true
     mode: "0755"
     marker_begin: "# BEGIN ANSIBLE MANAGED BLOCK"
     marker_end: "# END ANSIBLE MANAGED BLOCK"
@@ -77,6 +77,7 @@
     {{ runner_extra_config_args }}"
   args:
     chdir: "{{ runner_dir }}"
+  changed_when: true
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
@@ -95,14 +96,19 @@
     --replace"
   args:
     chdir: "{{ runner_dir }}"
+  changed_when: true
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
-  when: runner_name in registered_runners.json.runners|map(attribute='name')|list and reinstall_runner and not runner_org
+  when: >
+    runner_name in registered_runners.json.runners|map(attribute='name')|list and
+    reinstall_runner and
+    not runner_org
 
 - name: Install service
   ansible.builtin.command: "./svc.sh install {{ runner_user }}"
   args:
     chdir: "{{ runner_dir }}"
+  changed_when: true
   become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
   when: not runner_service_file_path.stat.exists
 
@@ -117,7 +123,11 @@
     chdir: "{{ runner_dir }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   ignore_errors: "{{ ansible_check_mode }}"
-  when: ansible_system != 'Darwin' and runner_state|lower == "started" and ansible_facts.services[(runner_service.content | b64decode) | trim ]['state'] != 'running'
+  changed_when: true
+  when: >
+    ansible_system != 'Darwin' and
+    runner_state|lower == "started" and
+    ansible_facts.services[(runner_service.content | b64decode) | trim ]['state'] != 'running'
 
 - name: START and enable Github Actions Runner service (macOS) # TODO: Idempotence
   ansible.builtin.command: "./svc.sh start"
@@ -126,25 +136,24 @@
   become: false
   no_log: "{{ hide_sensitive_logs | bool }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  changed_when: true
   when: ansible_system == 'Darwin' and runner_state|lower
 
 - name: STOP and disable Github Actions Runner service
-  ansible.builtin.shell: "./svc.sh stop"
+  ansible.builtin.command: "./svc.sh stop"
   args:
     chdir: "{{ runner_dir }}"
+  changed_when: true
   become: "{{ 'false' if ansible_distribution == 'MacOS' else 'true' }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   ignore_errors: "{{ ansible_check_mode }}"
   when: runner_state|lower == "stopped"
 
 - name: Version changed - RESTART Github Actions Runner service
-  ansible.builtin.shell:
-    cmd: |
-      ./svc.sh stop
-      sleep 5
-      ./svc.sh start
+  ansible.builtin.command: "./svc.sh stop && sleep 5 && ./svc.sh start"
   args:
     chdir: "{{ runner_dir }}"
+  changed_when: true
   become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -51,12 +51,17 @@
 - name: Set complete GitHub url for repo runner
   ansible.builtin.set_fact:
     github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}/{{ github_repo }}"
-  when: not runner_org
+  when: not runner_org and not runner_enterprise
 
 - name: Set complete GitHub url for org runner
   ansible.builtin.set_fact:
     github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}"
-  when: runner_org | bool
+  when: runner_org | bool and not runner_enterprise
+
+- name: Set complete GitHub url for enterprise runner
+  ansible.builtin.set_fact:
+    github_full_url: "{{ github_url }}/enterprises/{{ github_enterprise }}"
+  when: runner_enterprise
 
 - name: Register runner
   environment:

--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -8,6 +8,7 @@
   ansible.builtin.command: "./svc.sh uninstall"
   args:
     chdir: "{{ runner_dir }}"
+  changed_when: true
   become: "{{ 'false' if ansible_system == 'Darwin' else 'true' }}"
   when: runner_service_file_path.stat.exists
 
@@ -25,6 +26,7 @@
   become: false
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
+  changed_when: true
   when: runner_name in registered_runners.json.runners|map(attribute='name')|list and runner_file.stat.exists
 
 - name: Delete runner directory


### PR DESCRIPTION
# Description

Add support for **enterprise-owned** Github runners.

Setting `vars.github_enterprise` to your enterprise name and using a PAT with the proper rights, you can install+register enterprise-managed runners.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update _(README updated)_
- [X] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Well, of course I've tested it locally, this is what I can show you:
```log
TASK [danielefranceschi.github_actions_runner : START and enable Github Actions Runner service (Linux)] **********************************************************
task path: /home/daniele/.ansible/roles/danielefranceschi.github_actions_runner/tasks/install_runner.yml:120
changed: [github-runner-01] => {"changed": true, "cmd": ["./svc.sh", "start"], "delta": "0:00:00.042938", "end": "2023-08-02 11:15:00.562493", "msg": "", "rc": 0, "start": "2023-08-02 11:15:00.519555", "stderr": "", "stderr_lines": [],
"stdout": "\n/etc/systemd/system/actions.runner.enterprises-REDACTED.github-runner-01.service\n* actions.runner.enterprises-REDACTED.github-runner-01.service - GitHub Actions Runner (enterprises-REDACTED.github-runner-01)\n     Loaded: loaded (/etc/systemd/system/actions.runner.enterprises-REDACTED.github-runner-01.service; enabled; vendor preset: enabled)\n     Active: active (running) since Wed 2023-08-02 11:15:00 EST; 8ms ago\n   Main PID: 9726 (runsvc.sh)\n      Tasks: 2 (limit: 9402)\n     Memory: 592.0K\n        CPU: 6ms\n     CGroup: /system.slice/actions.runner.enterprises-REDACTED.github-runner-01.service\n             ├─9726 /bin/bash /opt/actions-runner/runsvc.sh\n             └─9729 ./externals/node16/bin/node ./bin/RunnerService.js\n\nAug 02 11:15:00 github-runner-01 systemd[1]: Started GitHub Actions Runner (enterprises-REDACTED.github-runner-01).\nAug 02 11:15:00 github-runner-01 runsvc.sh[9726]: .path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
"stdout_lines": ["", "/etc/systemd/system/actions.runner.enterprises-REDACTED.github-runner-01.service", "* actions.runner.enterprises-REDACTED.github-runner-01.service - GitHub Actions Runner (enterprises-REDACTED.github-runner-01)", "     Loaded: loaded (/etc/systemd/system/actions.runner.enterprises-REDACTED.github-runner-01.service; enabled; vendor preset: enabled)", "     Active: active (running) since Wed 2023-08-02 11:15:00 EST; 8ms ago", "   Main PID: 9726 (runsvc.sh)", "      Tasks: 2 (limit: 9402)", "     Memory: 592.0K", "        CPU: 6ms", "     CGroup: /system.slice/actions.runner.enterprises-REDACTED.github-runner-01.service", "             ├─9726 /bin/bash /opt/actions-runner/runsvc.sh", "             └─9729 ./externals/node16/bin/node ./bin/RunnerService.js", "", "Aug 02 11:15:00 github-runner-01 systemd[1]: Started GitHub Actions Runner (enterprises-REDACTED.github-runner-01).", "Aug 02 11:15:00 github-runner-01 runsvc.sh[9726]: .path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"]}
```

## changes made to the code

- `assert.yml`: disable org/account checks when enterprise is given
- `collect_info.yml`: set runner API URL for enterprises
- `install_runner.yml`: set GH full URL for enterprises

Minor changes for (aggressive IMO) linting here and there.
