### PR TITLE
chore: fix ansible-lint 6.17.2

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,6 @@
+---
 skip_list:
   - '106'
   - ignore-errors
+exclude_paths:
+  - .github/workflows/

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,5 +2,6 @@
 skip_list:
   - '106'
   - ignore-errors
+  - yaml[truthy]
 exclude_paths:
   - .github/workflows/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      SUITE: default
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
@@ -22,7 +24,10 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible-lint yamllint
+        run: |
+          pip3 install ansible-lint yamllint
+          [ -f molecule/${SUITE}/requirements.yml ] && ansible-galaxy install -r molecule/${SUITE}/requirements.yml
+          { echo '[defaults]'; echo 'callbacks_enabled = profile_tasks, timer'; echo 'roles_path = ../:/home/runner/.ansible/roles'; echo 'ansible_python_interpreter: /usr/bin/python3'; } >> ansible.cfg
 
       - name: Lint code.
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - devel*
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,12 +12,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
+      ANSIBLE_ROLE: monolithprojects.github_actions_runner
       SUITE: default
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
         with:
-          path: "${{ github.repository }}"
+          path: ${{ env.ANSIBLE_ROLE }}
 
       - name: Set up Python 3.
         uses: actions/setup-python@v4
@@ -32,4 +33,4 @@ jobs:
 
       - name: Lint code.
         run: |
-          ansible-lint --exclude molecule/ --exclude .github/
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && ansible-lint --exclude molecule/ --exclude .github/

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - devel*
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,8 @@ name: molecule test
 on:
   pull_request:
     branches:
-        - master
+      - master
+      - devel*
     types: [opened, synchronize, reopened]
     paths:
       - 'defaults/**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,10 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2" jmespath
+        run: |
+          pip3 install ansible docker molecule molecule-plugins[docker] "requests<2.29.2" jmespath
+          # https://github.com/ansible/molecule/issues/4017
+          pip3 install ansible ansible-core==2.15.2 ansible-compat==4.1.5 'molecule<6' molecule-plugins[docker] docker
 
       - name: Run Molecule test - repo
         run: molecule test --scenario-name repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.0.1
-      hooks:
-        - id: check-yaml
-          args: [--allow-multiple-documents]
-        - id: end-of-file-fixer
-        - id: trailing-whitespace
-          args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
 
-    - repo: https://github.com/adrienverge/yamllint
-      rev: v1.26.3
-      hooks:
-        - id: yamllint
-          args: [-c=.yamllint]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+        args: [-c=.yamllint]
 
-    - repo: https://github.com/robertdebock/pre-commit
-      rev: v1.2.3
-      hooks:
-        - id: ansible_role_find_unused_variable
-        - id: ansible_role_find_empty_files
-        - id: ansible_role_find_empty_directories
-        - id: ansible_role_fix_readability
+  - repo: https://github.com/robertdebock/pre-commit
+    rev: v1.2.3
+    hooks:
+      - id: ansible_role_find_unused_variable
+      - id: ansible_role_find_empty_files
+      - id: ansible_role_find_empty_directories
+      - id: ansible_role_fix_readability

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,10 +12,10 @@ runner_version: "latest"
 runner_state: "started"
 
 # If found on the server, delete already existing runner service and install it again
-reinstall_runner: no
+reinstall_runner: false
 
 # Do not show Ansible logs which may contain sensitive data (registration token)
-hide_sensitive_logs: yes
+hide_sensitive_logs: true
 
 # GitHub address
 github_url: "https://github.com"
@@ -27,7 +27,7 @@ github_api_url: "https://api.github.com"
 access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
 
 # Is it the runner for organization or not?
-runner_org: no
+runner_org: false
 
 # Labels to apply to the runner
 runner_labels: []

--- a/molecule/custom_env/cleanup.yml
+++ b/molecule/custom_env/cleanup.yml
@@ -4,9 +4,9 @@
   hosts: all
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - runner_state: absent
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    runner_state: absent
   roles:
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/custom_env/converge.yml
+++ b/molecule/custom_env/converge.yml
@@ -5,16 +5,16 @@
   gather_facts: yes
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - runner_version: "latest"
-    - runner_labels:
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    runner_version: "latest"
+    runner_labels:
         - label1
         - repo-runner
-    - custom_env: |
+    custom_env: |
       # HTTPS_PROXY=YOUR_URL_HERE
 
   roles:
     - robertdebock.epel
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/custom_env/requirements.yml
+++ b/molecule/custom_env/requirements.yml
@@ -1,3 +1,5 @@
 ---
+
+roles:
 - role: robertdebock.epel
   version: 3.0.1

--- a/molecule/custom_env/requirements.yml
+++ b/molecule/custom_env/requirements.yml
@@ -1,5 +1,5 @@
 ---
 
 roles:
-- role: robertdebock.epel
+- name: robertdebock.epel
   version: 3.0.1

--- a/molecule/custom_env/verify.yml
+++ b/molecule/custom_env/verify.yml
@@ -1,20 +1,20 @@
 ---
-- name: validate Repo runners
+- name: Validate Repo runners
   user: ansible
   hosts: all
   gather_facts: yes
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - github_api_url: "https://api.github.com"
-    - access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
-    - runner_name: ubuntu16-latest
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    github_api_url: "https://api.github.com"
+    access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
+    runner_name: ubuntu16-latest
 
   tasks:
     - name: Check currently registered runners
-      uri:
+      ansible.builtin.uri:
         url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
         headers:
           Authorization: "token {{ access_token }}"
@@ -24,23 +24,24 @@
         force_basic_auth: yes
       register: registered_runners
 
-    - debug:
+    - name: Debug | var registered_runners
+      ansible.builtin.debug:
         var: registered_runners.json.runners
 
     - name: Check Runner
-      assert:
+      ansible.builtin.assert:
         that:
           - runner_name in registered_runners.json.runners|map(attribute='name')|list
           - registered_runners.json.runners|map(attribute='status') == ["online"]
         quiet: true
 
     - name: Check Labels (skipped if labels are OK)
-      fail:
+      ansible.builtin.fail:
         msg: Woops some labels differ "{{ (registered_runners.json.runners.0 | json_query('labels[*].name') | difference(['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'])) }}"
       when: not (registered_runners.json.runners.0 | json_query('labels[*].name') | list ) == (['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'] | list)
 
     - name: Check custom env file is configured
-      lineinfile:
+      ansible.builtin.lineinfile:
         dest: /opt/actions-runner/.env
         line: "# HTTPS_PROXY=YOUR_URL_HERE"
       check_mode: yes

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -4,10 +4,10 @@
   hosts: all
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - runner_state: absent
-    - runner_name: test_name
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    runner_state: absent
+    runner_name: test_name
   roles:
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,17 +5,17 @@
   gather_facts: yes
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - runner_version: "latest"
-    - runner_name: test_name
-    - runner_on_ghes: yes
-    - reinstall_runner: false
-    - hide_sensitive_logs: no
-    - runner_labels:
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    runner_version: "latest"
+    runner_name: test_name
+    runner_on_ghes: yes
+    reinstall_runner: false
+    hide_sensitive_logs: no
+    runner_labels:
         - label1
         - repo-runner
   roles:
     - robertdebock.epel
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,5 @@
 ---
+
+roles:
 - role: robertdebock.epel
   version: 3.0.1

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,5 +1,5 @@
 ---
 
 roles:
-- role: robertdebock.epel
+- name: robertdebock.epel
   version: 3.0.1

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,20 +1,20 @@
 ---
-- name: validate Repo runners
+- name: Validate Repo runners
   user: ansible
   hosts: all
   gather_facts: yes
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - github_api_url: "https://api.github.com"
-    - access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
-    - runner_name: ubuntu16-latest
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    github_api_url: "https://api.github.com"
+    access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
+    runner_name: ubuntu16-latest
 
   tasks:
     - name: Check currently registered runners
-      uri:
+      ansible.builtin.uri:
         url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
         headers:
           Authorization: "token {{ access_token }}"
@@ -24,17 +24,18 @@
         force_basic_auth: yes
       register: registered_runners
 
-    - debug:
+    - name: Debug | var registered_runners
+      ansible.builtin.debug:
         var: registered_runners.json.runners
 
     - name: Check Runner
-      assert:
+      ansible.builtin.assert:
         that:
           - runner_name in registered_runners.json.runners|map(attribute='name')|list
           - registered_runners.json.runners|map(attribute='status') == ["online"]
         quiet: true
 
     - name: Check Labels (skipped if labels are OK)
-      fail:
+      ansible.builtin.fail:
         msg: Woops some labels differ "{{ (registered_runners.json.runners.0 | json_query('labels[*].name') | difference(['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'])) }}"
       when: not (registered_runners.json.runners.0 | json_query('labels[*].name') | list ) == (['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'] | list)

--- a/molecule/org/cleanup.yml
+++ b/molecule/org/cleanup.yml
@@ -4,9 +4,9 @@
   hosts: all
   become: yes
   vars:
-    - runner_user: ansible
-    - github_account: monolithprojects-testorg
-    - runner_org: yes
-    - runner_state: absent
+    runner_user: ansible
+    github_account: monolithprojects-testorg
+    runner_org: yes
+    runner_state: absent
   roles:
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/org/converge.yml
+++ b/molecule/org/converge.yml
@@ -4,11 +4,11 @@
   hosts: all
   become: yes
   vars:
-    - runner_user: ansible
-    - github_account: monolithprojects-testorg
-    - runner_org: yes
-    - runner_state: "stopped"
-    - runner_version: "2.303.0"
+    runner_user: ansible
+    github_account: monolithprojects-testorg
+    runner_org: yes
+    runner_state: "stopped"
+    runner_version: "2.303.0"
   roles:
     - robertdebock.epel
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/org/requirements.yml
+++ b/molecule/org/requirements.yml
@@ -1,3 +1,5 @@
 ---
+
+roles:
 - role: robertdebock.epel
   version: 3.0.1

--- a/molecule/org/requirements.yml
+++ b/molecule/org/requirements.yml
@@ -1,5 +1,5 @@
 ---
 
 roles:
-- role: robertdebock.epel
+- name: robertdebock.epel
   version: 3.0.1

--- a/molecule/org/verify.yml
+++ b/molecule/org/verify.yml
@@ -1,24 +1,24 @@
 ---
-- name: validate Repo runners
+- name: Validate Repo runners
   user: ansible
   hosts: all
   gather_facts: yes
   become: yes
   vars:
-    - runner_user: ansible
-    - github_account: monolithprojects-testorg
-    - runner_org: yes
-    - github_api_url: "https://api.github.com"
-    - access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
-    - runner_name: "{{ ansible_hostname }}"
+    runner_user: ansible
+    github_account: monolithprojects-testorg
+    runner_org: yes
+    github_api_url: "https://api.github.com"
+    access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
+    runner_name: "{{ ansible_hostname }}"
 
   tasks:
     - name: Give the runners a minute
-      pause:
+      ansible.builtin.pause:
         seconds: 30
 
     - name: Check currently registered runners
-      uri:
+      ansible.builtin.uri:
         url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
         headers:
           Authorization: "token {{ access_token }}"
@@ -29,7 +29,7 @@
       register: registered_runners
 
     - name: Check Runner
-      assert:
+      ansible.builtin.assert:
         that:
           - runner_name in registered_runners.json.runners|map(attribute='name')|list
         quiet: true

--- a/molecule/repo/cleanup.yml
+++ b/molecule/repo/cleanup.yml
@@ -4,9 +4,9 @@
   hosts: all
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - runner_state: absent
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    runner_state: absent
   roles:
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/repo/converge.yml
+++ b/molecule/repo/converge.yml
@@ -5,13 +5,13 @@
   gather_facts: yes
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - runner_version: "latest"
-    - runner_labels:
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    runner_version: "latest"
+    runner_labels:
         - label1
         - repo-runner
   roles:
     - robertdebock.epel
-    - ansible-github_actions_runner
+    - monolithprojects.github_actions_runner

--- a/molecule/repo/requirements.yml
+++ b/molecule/repo/requirements.yml
@@ -1,3 +1,5 @@
 ---
+
+roles:
 - role: robertdebock.epel
   version: 3.0.1

--- a/molecule/repo/requirements.yml
+++ b/molecule/repo/requirements.yml
@@ -1,5 +1,5 @@
 ---
 
 roles:
-- role: robertdebock.epel
+- name: robertdebock.epel
   version: 3.0.1

--- a/molecule/repo/verify.yml
+++ b/molecule/repo/verify.yml
@@ -1,24 +1,24 @@
 ---
-- name: validate Repo runners
+- name: Validate Repo runners
   user: ansible
   hosts: all
   gather_facts: yes
   become: yes
   vars:
-    - runner_user: ansible
-    - github_repo: ansible-github_actions_runner-testrepo
-    - github_account: monolithprojects-testorg
-    - github_api_url: "https://api.github.com"
-    - access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
-    - runner_name: "{{ ansible_hostname }}"
+    runner_user: ansible
+    github_repo: ansible-github_actions_runner-testrepo
+    github_account: monolithprojects-testorg
+    github_api_url: "https://api.github.com"
+    access_token: "{{ lookup('env', 'PERSONAL_ACCESS_TOKEN') }}"
+    runner_name: "{{ ansible_hostname }}"
 
   tasks:
     - name: Give the runners some time
-      pause:
+      ansible.builtin.pause:
         seconds: 30
 
     - name: Check currently registered runners
-      uri:
+      ansible.builtin.uri:
         url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
         headers:
           Authorization: "token {{ access_token }}"
@@ -28,16 +28,17 @@
         force_basic_auth: yes
       register: registered_runners
 
-    - debug:
+    - name: Debug | var registered_runners
+      ansible.builtin.debug:
         var: registered_runners.json.runners|map(attribute='status')
 
     - name: Check Runner
-      assert:
+      ansible.builtin.assert:
         that:
           - runner_name in registered_runners.json.runners|map(attribute='name')|list
         quiet: true
 
     - name: Check Labels (skipped if labels are OK)
-      fail:
+      ansible.builtin.fail:
         msg: Woops some labels differ "{{ (registered_runners.json.runners.0 | json_query('labels[*].name') | difference(['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'])) }}"
       when: not (registered_runners.json.runners.0 | json_query('labels[*].name') | list ) == (['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'] | list)

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -2,71 +2,71 @@
 - name: Info collections
   check_mode: false
   block:
-  - name: Set complete API url for repo runner
-    ansible.builtin.set_fact:
-      github_full_api_url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
-    when: not runner_org
+    - name: Set complete API url for repo runner
+      ansible.builtin.set_fact:
+        github_full_api_url: "{{ github_api_url }}/repos/{{ github_owner | default(github_account) }}/{{ github_repo }}/actions/runners"
+      when: not runner_org
 
-  - name: Set complete API url for org runner
-    ansible.builtin.set_fact:
-      github_full_api_url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
-    when: runner_org | bool
+    - name: Set complete API url for org runner
+      ansible.builtin.set_fact:
+        github_full_api_url: "{{ github_api_url }}/orgs/{{ github_owner | default(github_account) }}/actions/runners"
+      when: runner_org | bool
 
-  - name: Get registration token (RUN ONCE)
-    ansible.builtin.uri:
-      url: "{{ github_full_api_url }}/registration-token"
-      headers:
-        Authorization: "token {{ access_token }}"
-        Accept: "application/vnd.github.v3+json"
-      method: POST
-      status_code: 201
-      force_basic_auth: yes
-    register: registration
-    run_once: true
+    - name: Get registration token (RUN ONCE)
+      ansible.builtin.uri:
+        url: "{{ github_full_api_url }}/registration-token"
+        headers:
+          Authorization: "token {{ access_token }}"
+          Accept: "application/vnd.github.v3+json"
+        method: POST
+        status_code: 201
+        force_basic_auth: true
+      register: registration
+      run_once: true
 
-  - name: Check currently registered runners for repo (RUN ONCE)
-    ansible.builtin.uri:
-      url: "{{ github_full_api_url }}"
-      headers:
-        Authorization: "token {{ access_token }}"
-        Accept: "application/vnd.github.v3+json"
-      method: GET
-      status_code: 200
-      force_basic_auth: yes
-    register: registered_runners
-    run_once: true
+    - name: Check currently registered runners for repo (RUN ONCE)
+      ansible.builtin.uri:
+        url: "{{ github_full_api_url }}"
+        headers:
+          Authorization: "token {{ access_token }}"
+          Accept: "application/vnd.github.v3+json"
+        method: GET
+        status_code: 200
+        force_basic_auth: true
+      register: registered_runners
+      run_once: true
 
-  - name: Get Runner User IDs
-    ansible.builtin.command: id -u "{{ runner_user }}"
-    changed_when: false
-    register: runner_user_id
+    - name: Get Runner User IDs
+      ansible.builtin.command: id -u "{{ runner_user }}"
+      changed_when: false
+      register: runner_user_id
 
-  - name: Get Runner Group IDs
-    ansible.builtin.command: id -g "{{ runner_user }}"
-    changed_when: false
-    register: runner_user_group_id
+    - name: Get Runner Group IDs
+      ansible.builtin.command: id -g "{{ runner_user }}"
+      changed_when: false
+      register: runner_user_group_id
 
-  - name: Set runner_system variable
-    ansible.builtin.set_fact:
-      runner_system: "{{ 'osx' if ansible_system == 'Darwin' else 'linux' }}"
+    - name: Set runner_system variable
+      ansible.builtin.set_fact:
+        runner_system: "{{ 'osx' if ansible_system == 'Darwin' else 'linux' }}"
 
-  - name: Find the latest runner version (RUN ONCE)
-    ansible.builtin.uri:
-      url: "https://api.github.com/repos/{{ runner_download_repository }}/releases/latest"
-      headers:
-        Content-Type: "application/json"
-      method: GET
-      return_content: yes
-      status_code: 200
-      body_format: json
-    check_mode: false
-    register: api_response
-    run_once: true
-    become: false
-    delegate_to: localhost
-    when: runner_version == "latest"
+    - name: Find the latest runner version (RUN ONCE)
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ runner_download_repository }}/releases/latest"
+        headers:
+          Content-Type: "application/json"
+        method: GET
+        return_content: true
+        status_code: 200
+        body_format: json
+      check_mode: false
+      register: api_response
+      run_once: true
+      become: false
+      delegate_to: localhost
+      when: runner_version == "latest"
 
-  - name: Get systemd service facts
-    ansible.builtin.service_facts:
-    register: service_facts
-    when: ansible_system == "Linux"
+    - name: Get systemd service facts
+      ansible.builtin.service_facts:
+      register: service_facts
+      when: ansible_system == "Linux"

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: "{{ runner_dir }}"
     state: directory
-    mode: 0755
+    mode: '0755'
     owner: "{{ runner_user_id.stdout }}"
     group: "{{ runner_user_group_id.stdout }}"
 
@@ -27,7 +27,7 @@
     owner: "{{ runner_user_id.stdout }}"
     group: "{{ runner_user_group_id.stdout }}"
     remote_src: yes
-    mode: 0755
+    mode: '0755'
   environment:
     PATH: /usr/local/bin:/opt/homebrew/bin/:{{ ansible_env.HOME }}/bin:{{ ansible_env.PATH }}
   when: runner_version not in runner_installed.stdout or reinstall_runner
@@ -38,7 +38,7 @@
     block: "{{ custom_env }}"
     owner: "{{ runner_user }}"
     create: yes
-    mode: 0755
+    mode: '0755'
     marker_begin: "# BEGIN ANSIBLE MANAGED BLOCK"
     marker_end: "# END ANSIBLE MANAGED BLOCK"
   when: custom_env is defined
@@ -112,7 +112,10 @@
     chdir: "{{ runner_dir }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   ignore_errors: "{{ ansible_check_mode }}"
-  when: ansible_system != 'Darwin' and runner_state|lower == "started" and ansible_facts.services[(runner_service.content | b64decode) | trim ]['state'] != 'running'
+  when:
+    - ansible_system != 'Darwin'
+    - runner_state|lower == "started"
+    - ansible_facts.services[(runner_service.content | b64decode) | trim ]['state'] != 'running'
 
 - name: START and enable Github Actions Runner service (macOS) # TODO: Idempotence
   ansible.builtin.command: "./svc.sh start"  # noqa no-changed-when

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -58,7 +58,7 @@
     github_full_url: "{{ github_url }}/{{ github_owner | default(github_account) }}"
   when: runner_org | bool
 
-- name: Register runner
+- name: Register runner  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
   ansible.builtin.command:
@@ -76,7 +76,7 @@
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
 
-- name: Replace registered runner
+- name: Replace registered runner  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
   ansible.builtin.command:
@@ -94,7 +94,7 @@
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name in registered_runners.json.runners|map(attribute='name')|list and reinstall_runner and not runner_org
 
-- name: Install service
+- name: Install service  # noqa no-changed-when
   ansible.builtin.command: "./svc.sh install {{ runner_user }}"
   args:
     chdir: "{{ runner_dir }}"
@@ -106,7 +106,7 @@
     src: "{{ runner_dir }}/.service"
   register: runner_service
 
-- name: START and enable Github Actions Runner service (Linux)
+- name: START and enable Github Actions Runner service (Linux)  # noqa no-changed-when
   ansible.builtin.command: "./svc.sh start"
   args:
     chdir: "{{ runner_dir }}"
@@ -115,7 +115,7 @@
   when: ansible_system != 'Darwin' and runner_state|lower == "started" and ansible_facts.services[(runner_service.content | b64decode) | trim ]['state'] != 'running'
 
 - name: START and enable Github Actions Runner service (macOS) # TODO: Idempotence
-  ansible.builtin.command: "./svc.sh start"
+  ansible.builtin.command: "./svc.sh start"  # noqa no-changed-when
   args:
     chdir: "{{ runner_dir }}"
   become: false
@@ -123,8 +123,8 @@
   ignore_errors: "{{ ansible_check_mode }}"
   when: ansible_system == 'Darwin' and runner_state|lower
 
-- name: STOP and disable Github Actions Runner service
-  ansible.builtin.shell: "./svc.sh stop"
+- name: STOP and disable Github Actions Runner service  # noqa no-changed-when
+  ansible.builtin.command: "./svc.sh stop"
   args:
     chdir: "{{ runner_dir }}"
   become: "{{ 'false' if ansible_distribution == 'MacOS' else 'true' }}"
@@ -133,7 +133,7 @@
   when: runner_state|lower == "stopped"
 
 - name: Version changed - RESTART Github Actions Runner service
-  ansible.builtin.shell:
+  ansible.builtin.shell:  # noqa no-changed-when
     cmd: |
       ./svc.sh stop
       sleep 5

--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -4,7 +4,7 @@
     path: "{{ runner_dir }}/.service"
   register: runner_service_file_path
 
-- name: Uninstall runner
+- name: Uninstall runner  # noqa no-changed-when
   ansible.builtin.command: "./svc.sh uninstall"
   args:
     chdir: "{{ runner_dir }}"
@@ -16,7 +16,7 @@
     path: "{{ runner_dir }}/.runner"
   register: runner_file
 
-- name: Unregister runner from the GitHub
+- name: Unregister runner from the GitHub  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
   ansible.builtin.command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"


### PR DESCRIPTION
# Description

* chore: fix ansible-lint 6.17.2
* ci: include devel* branches
* ci: temporary workaround for molecule+docker upstream issue (4017)

## Type of change

- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Github workflow
* lint ok
* molecule test nok
https://github.com/juju4/ansible-github_actions_runner/actions/runs/5986256812/job/16239199822#step:5:141
```
      "msg": "access_token was not found or is using an invalid format."
```
but dependent on environment PERSONAL_ACCESS_TOKEN for which there is no matching change.
I would think that this would work fine on your side.