### PR TITLE
fix: add become to become_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # GitHub Actions Runner
 
 [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
-[![Galaxy Quality](https://img.shields.io/ansible/quality/47375?style=flat&logo=ansible)](https://galaxy.ansible.com/monolithprojects/github_actions_runner)
-[![Role version](https://img.shields.io/github/v/release/MonolithProjects/ansible-github_actions_runner)](https://galaxy.ansible.com/monolithprojects/github_actions_runner)
-[![Role downloads](https://img.shields.io/ansible/role/d/47375)](https://galaxy.ansible.com/monolithprojects/github_actions_runner)
+[![Role version](https://img.shields.io/github/v/release/MonolithProjects/ansible-github_actions_runner)](https://galaxy.ansible.com/ui/standalone/roles/monolithprojects/github_actions_runner/)
+[![Role downloads](https://img.shields.io/ansible/role/d/19739)](https://galaxy.ansible.com/ui/standalone/roles/monolithprojects/github_actions_runner/)
 [![Molecule test](https://github.com/MonolithProjects/ansible-github_actions_runner/actions/workflows/tests.yml/badge.svg)](https://github.com/MonolithProjects/ansible-github_actions_runner/actions/workflows/tests.yml)
 [![License](https://img.shields.io/github/license/MonolithProjects/ansible-github_actions_runner)](https://github.com/MonolithProjects/ansible-github_actions_runner/blob/main/LICENSE)
 

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -79,6 +79,7 @@
     chdir: "{{ runner_dir }}"
   changed_when: true
   become_user: "{{ runner_user }}"
+  become: true
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
 
@@ -98,6 +99,7 @@
     chdir: "{{ runner_dir }}"
   changed_when: true
   become_user: "{{ runner_user }}"
+  become: true
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: >
     runner_name in registered_runners.json.runners|map(attribute='name')|list and


### PR DESCRIPTION
# Description

Linting is failing with `"become_user" should have a corresponding "become" at the play or task level.` Fixed the failing tasks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
molecule
