### PR TITLE
:bug: Fix error become_user

### DIFF
--- a/tasks/uninstall_runner.yml
+++ b/tasks/uninstall_runner.yml
@@ -23,7 +23,7 @@
   ansible.builtin.command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
   args:
     chdir: "{{ runner_dir }}"
-  become: false
+  become: true
   become_user: "{{ runner_user }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   changed_when: true


### PR DESCRIPTION
become_user isn't effective is become flag by default is false, it is shown when you're working with a different user instead the remote_user for github_runner.

# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `master` branch.
--->
