### PR TITLE
Include arm64 in github_actions_architecture_map to support ARM Mac installations

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,4 +5,5 @@ github_actions_architecture_map:
   x86_64: x64
   armv7l: arm
   aarch64: arm64
+  arm64: arm64
 github_actions_architecture: "{{ github_actions_architecture_map[ansible_facts.architecture] }}"


### PR DESCRIPTION
# Description

When running on a ARM mac (Mac Studio) it will report `arm64` as the response when running `arch`.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I just ran it with this in place and it was able to map it.
