### PR TITLE
Let "Replace runner" work with orgs

### DIFF
--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -103,8 +103,7 @@
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: >
     runner_name in registered_runners.json.runners|map(attribute='name')|list and
-    reinstall_runner and
-    not runner_org
+    reinstall_runner
 
 - name: Install service  # noqa no-changed-when
   ansible.builtin.command: "./svc.sh install {{ runner_user }}"


### PR DESCRIPTION
# Description
When replacing an existing runner, it makes no sense to restrict it to not run it on org runners. This commit removes that requirement.
If there is a hidden assumption that requires it to not run on orgs, please let me know :)

Potentially closes: #207 and #198

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I tested this by deploying the role to my infrastructure multiple times, with `reinstall_runner: true`
Recreating a github runner is still "failing" because it is trying to redo the service files that are already installed, but it sets up the runner correctly