### PR TITLE
Allow different repos in same play

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ runner_extra_config_args: ""
 # Name to assign to this runner in GitHub (System hostname as default)
 runner_name: "{{ ansible_facts.hostname }}"
 
+# Set to false when provisioning runners for more than one repository within single play
+all_runners_in_same_repo: true
+
 # GitHub Repository user or Organization owner used for Runner registration
 # github_account: "youruser"
 
@@ -292,7 +295,7 @@ cd path/to/monolithprojects.github_actions_runner
 ```bash
 export PERSONAL_ACCESS_TOKEN=your_github_pat # Your Personal Access Token to Github
 export GITHUB_ACCOUNT=your_account # Your Github Account
-export GITHUB_ACCOUNT=your_repository # Github Repository where you want to setup the Runner
+export GITHUB_REPO=your_repository # Github Repository where you want to setup the Runner
 ```
 
 3. Run Molecule:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,9 @@ runner_extra_config_args: ""
 # Name to assign to this runner in GitHub (System hostname as default)
 runner_name: "{{ ansible_facts.hostname }}"
 
+# Set to false when provisioning runners for more than one repository within single play
+all_runners_in_same_repo: true
+
 # GitHub Repository user or Organization owner used for Runner registration
 # github_account: "youruser"
 

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -29,7 +29,7 @@
       register: registration
       run_once: true
 
-    - name: Check currently registered runners for repo (RUN ONCE)
+    - name: "Check currently registered runners for repo {{ '(RUN ONCE)' if all_runners_in_same_repo else '' }}"
       ansible.builtin.uri:
         url: "{{ github_full_api_url }}"
         headers:
@@ -42,7 +42,7 @@
         status_code: 200
         force_basic_auth: true
       register: registered_runners
-      run_once: true
+      run_once: "{{ all_runners_in_same_repo }}"
 
     - name: Get Runner User IDs
       ansible.builtin.command: id -u "{{ runner_user }}"


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

Adds new setting `all_runners_in_same_repo` with default value true (to preserve existing behavior). When set to false checking currently registered runners happens on per-runner basis instead of once. This prevents registration failures when provisioning runners for more than one repository in single play

Additionally small error in README.md was corrected

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `master` branch.
--->
