### PR TITLE
Resolve #217 - Update runner labels when needed

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,3 +19,26 @@
   roles:
     - robertdebock.epel
     - monolithprojects.github_actions_runner
+
+# Run the playbook again with different labels to test
+- name: Dev test playbook second run
+  user: ansible
+  hosts: all
+  gather_facts: yes
+  become: yes
+  vars:
+    runner_user: ansible
+    github_repo: "{{ lookup('env', 'GITHUB_REPO') }}"
+    github_account: "{{ lookup('env', 'GITHUB_ACCOUNT') }}"
+    runner_version: "latest"
+    runner_name: test_name
+    runner_on_ghes: yes
+    reinstall_runner: false
+    hide_sensitive_logs: no
+    runner_labels:
+        - label1
+        - repo-runner
+        - label2
+  roles:
+    - robertdebock.epel
+    - monolithprojects.github_actions_runner

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -37,5 +37,5 @@
 
     - name: Check Labels (skipped if labels are OK)
       ansible.builtin.fail:
-        msg: Woops some labels differ "{{ (registered_runners.json.runners.0 | json_query('labels[*].name') | difference(['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'])) }}"
-      when: not (registered_runners.json.runners.0 | json_query('labels[*].name') | list ) == (['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'] | list)
+        msg: Woops some labels differ "{{ (registered_runners.json.runners.0 | json_query('labels[*].name') | difference(['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner', 'label2'])) }}"
+      when: not (registered_runners.json.runners.0 | json_query('labels[*].name') | list ) == (['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner', 'label2'] | list)

--- a/molecule/repo/converge.yml
+++ b/molecule/repo/converge.yml
@@ -15,3 +15,22 @@
   roles:
     - robertdebock.epel
     - monolithprojects.github_actions_runner
+
+# Run the playbook again with different labels to test
+- name: Update Repo runner
+  user: ansible
+  hosts: all
+  gather_facts: yes
+  become: yes
+  vars:
+    runner_user: ansible
+    github_repo: "{{ lookup('env', 'GITHUB_REPO') }}"
+    github_account: "{{ lookup('env', 'GITHUB_ACCOUNT') }}"
+    runner_version: "latest"
+    runner_labels:
+        - label1
+        - repo-runner
+        - label2
+  roles:
+    - robertdebock.epel
+    - monolithprojects.github_actions_runner

--- a/molecule/repo/verify.yml
+++ b/molecule/repo/verify.yml
@@ -36,5 +36,5 @@
 
     - name: Check Labels (skipped if labels are OK)
       ansible.builtin.fail:
-        msg: Woops some labels differ "{{ (registered_runners.json.runners.0 | json_query('labels[*].name') | difference(['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'])) }}"
-      when: not (registered_runners.json.runners.0 | json_query('labels[*].name') | list ) == (['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner'] | list)
+        msg: Woops some labels differ "{{ (registered_runners.json.runners.0 | json_query('labels[*].name') | difference(['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner', 'label2'])) }}"
+      when: not (registered_runners.json.runners.0 | json_query('labels[*].name') | list ) == (['self-hosted', 'Linux', 'X64', 'label1', 'repo-runner', 'label2'] | list)

--- a/tasks/install_runner.yml
+++ b/tasks/install_runner.yml
@@ -83,6 +83,25 @@
   no_log: "{{ hide_sensitive_logs | bool }}"
   when: runner_name not in registered_runners.json.runners|map(attribute='name')|list
 
+- name: Update runner labels if changed
+  ansible.builtin.uri:
+    url: "{{ github_full_api_url }}/{{ (registered_runners.json.runners | selectattr('name', 'equalto', runner_name) | first).id }}/labels"
+    headers:
+      Authorization: "Bearer {{ access_token }}"
+      Accept: "application/vnd.github+json"
+    method: PUT
+    body_format: json
+    body:
+      labels: "{{ runner_labels }}"
+    status_code: 200
+    force_basic_auth: true
+  when:
+    - runner_name in registered_runners.json.runners|map(attribute='name')|list
+    - (runner_labels | sort) != (registered_runners.json.runners | selectattr('name', 'equalto', runner_name) | first).labels |
+                                                                   selectattr('type', 'equalto', 'custom') |
+                                                                   map(attribute='name') |
+                                                                   list
+
 - name: Replace registered runner  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"


### PR DESCRIPTION
# Description

If the role is run against a runner that is
already registered, the role will now update the
runner labels if they have changed.

The tests have been updated to reflect this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

I have tested this against a physical runner I own as well as updating the molecule tests to reflect this change.
