### PR TITLE
Fixes Stoping service on MacOS

### DIFF
--- a/tasks/install_runner_unix.yml
+++ b/tasks/install_runner_unix.yml
@@ -165,7 +165,7 @@
   args:
     chdir: "{{ runner_dir }}"
   changed_when: true
-  become: "{{ 'false' if ansible_distribution == 'MacOS' else 'true' }}"
+  become: "{{ 'false' if ansible_distribution == 'MacOSX' else 'true' }}"
   no_log: "{{ hide_sensitive_logs | bool }}"
   ignore_errors: "{{ ansible_check_mode }}"
   when: runner_state|lower == "stopped"


### PR DESCRIPTION
# Description

Resolves the following error due to how `ansible_distribution` resolves for macOS distributions as `MacOSX`.

```
TASK [monolithprojects.github_actions_runner : STOP and disable Github Actions Runner service] ****************************
fatal: [<hostname>]: FAILED! => {"changed": true, "cmd": ["./svc.sh", "stop"], "delta": "0:00:00.004103", "end": "2024-11-04 15:02:53.034496", "msg": "non-zero return code", "rc": 1, "start": "2024-11-04 15:02:53.030393", "stderr": "", "stderr_lines": [], "stdout": "Must not run with sudo", "stdout_lines": ["Must not run with sudo"]}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Used this to stop some self hosted macOS runners.
