### PR TITLE
fix flaky 'find the latest runner version (RUN ONCE)' step

### DIFF
--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -64,6 +64,7 @@
       ansible.builtin.uri:
         url: "https://api.github.com/repos/{{ runner_download_repository }}/releases/latest"
         headers:
+          Authorization: "token {{ access_token }}"
           Content-Type: "application/json"
         method: GET
         return_content: true


### PR DESCRIPTION
# Description

Seems the authorization token was simply missed on this step, but not on the others. Causes 403 rate limit reached if you call this project often enough..

Fix was to simply copy over the same authorization token from a previous step to this step as well.

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Only tested manually.

<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `master` branch.
--->
