### PR TITLE
Force reinstallation when self-hosted Runner is not installed but is registered with Github Runners.

### DIFF
--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -48,6 +48,11 @@
       become: false
       run_once: "{{ all_runners_in_same_repo }}"
 
+    - name: Print registered runners (formatted JSON)
+      ansible.builtin.debug:
+        msg: "{{ registered_runners | to_nice_json }}"
+      when: registered_runners is defined
+
     - name: Get Runner User IDs
       ansible.builtin.command: id -u "{{ runner_user }}"
       changed_when: false

--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -33,25 +33,17 @@
 
     - name: "Check currently registered runners for repo {{ '(RUN ONCE)' if all_runners_in_same_repo else '' }}"
       ansible.builtin.uri:
-        url: "{{ github_full_api_url }}"
+        url: "{{ github_full_api_url }}{{ '?' if '?' not in github_full_api_url else '&' }}per_page={{ github_api_runners_per_page }}"
         headers:
           Authorization: "token {{ access_token }}"
           Accept: "application/vnd.github.v3+json"
         method: GET
-        body_format: form-urlencoded
-        body:
-          per_page: "{{ github_api_runners_per_page }}"
         status_code: 200
         force_basic_auth: true
       register: registered_runners
       delegate_to: localhost
       become: false
       run_once: "{{ all_runners_in_same_repo }}"
-
-    - name: Print registered runners (formatted JSON)
-      ansible.builtin.debug:
-        msg: "{{ registered_runners | to_nice_json }}"
-      when: registered_runners is defined
 
     - name: Get Runner User IDs
       ansible.builtin.command: id -u "{{ runner_user }}"

--- a/tasks/install_runner_unix.yml
+++ b/tasks/install_runner_unix.yml
@@ -19,12 +19,12 @@
   changed_when: false
   ignore_errors: true
 
-- name: Force reinstall if runner in registered_runners is offline (meaning the self-hosted runner is not tied to the Github runner)
+- name: Force reinstall if runner {{ runner_name }} in registered_runners is offline (meaning the self-hosted runner is not tied to the Github runner)
   ansible.builtin.set_fact:
     reinstall_runner: true
   when:
     - not reinstall_runner
-    - runner_name in registered_runners.json.runners|map(attribute='name')|list
+    - runner_name in (registered_runners.json.runners | map(attribute='name') | list)
     - (registered_runners.json.runners | selectattr('name', 'equalto', runner_name) | first).status == 'offline'
 
 - name: Unarchive runner package

--- a/tasks/install_runner_unix.yml
+++ b/tasks/install_runner_unix.yml
@@ -19,6 +19,14 @@
   changed_when: false
   ignore_errors: true
 
+- name: Force reinstall if runner in registered_runners is offline (meaning the self-hosted runner is not tied to the Github runner)
+  ansible.builtin.set_fact:
+    reinstall_runner: true
+  when:
+    - not reinstall_runner
+    - runner_name in registered_runners.json.runners|map(attribute='name')|list
+    - (registered_runners.json.runners | selectattr('name', 'equalto', runner_name) | first).status == 'offline'
+
 - name: Unarchive runner package
   ansible.builtin.unarchive:
     src: "https://github.com/{{ runner_download_repository }}/releases/download/v{{ runner_version }}/\


### PR DESCRIPTION
# Description

Force reinstallation when self-hosted Runner is not installed but is registered with Github Runners.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Internal Github Workflow that:

* Install agents
* check that agents are registered and online
* Uninstall agents
* check that agents are unregistered

this used to fail across runs before the fixes.

## Fixes

* detect if a runner with the same name is registered but offline and force reinstallation
* use a query parameter instead of a body form parameter (the latter does not seem to work and returns the default API 30 results instead of role defaults 100 results.
