### PR TITLE
proposed fix for #238

### DIFF
--- a/tasks/collect_info.yml
+++ b/tasks/collect_info.yml
@@ -33,13 +33,16 @@
 
     - name: "Check currently registered runners for repo {{ '(RUN ONCE)' if all_runners_in_same_repo else '' }}"
       ansible.builtin.uri:
-        url: "{{ github_full_api_url }}{{ '?' if '?' not in github_full_api_url else '&' }}per_page={{ github_api_runners_per_page }}"
+        url: "{{ github_full_api_url }}?{{ query_params | urlencode }}"
         headers:
           Authorization: "token {{ access_token }}"
           Accept: "application/vnd.github.v3+json"
         method: GET
         status_code: 200
         force_basic_auth: true
+      vars:
+        query_params:
+          per_page: "{{ github_api_runners_per_page }}"
       register: registered_runners
       delegate_to: localhost
       become: false


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

Restores correct behaviour of returning 100 (by default) GitHub Actions runners per page via the GitHub API

Fixes: #238

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `master` branch.
--->

I have run my company's internal workflow against our org with 44 total runners. With the `1.24.1` tag that we were using previously, the workflow fails because I'm trying to operate on the runners which fall between 31-44 alphabetically and this role sees them as new runners and tries to register them. With this proposed fix, the workflow succeeds because all 44 runners are returned by the API, and all runners are skipped.

**note:** this only pushes out the problem to 100 runners from the default of 30, the original issue in #197 mentions pagination via the `link` attribute in the response - I did not see this being returned from the API so I don't see how pagination could be automated.

I did not test explicitly with `master` or the latest tag for this role, as I couldn't see any differences in handling the `per_page` param between them and since this is not the actual problem I'm trying to fix (just a side quest that I hit while I was trying to fix a different work issue) I didn't want to bring in too many other changes.
