### PR TITLE
use environment variable to pass in registration token

### DIFF
--- a/tasks/install_runner_unix.yml
+++ b/tasks/install_runner_unix.yml
@@ -74,10 +74,10 @@
 - name: Register runner  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
+    ACTIONS_RUNNER_INPUT_TOKEN: "{{ registration.json.token }}"
   ansible.builtin.command:
     "{{ runner_dir }}/./config.sh \
     --url {{ github_full_url }} \
-    --token {{ registration.json.token }} \
     --name '{{ runner_name }}' \
     --labels {{ runner_labels | join(',') }} \
     --runnergroup {{ runner_group }} \
@@ -113,10 +113,10 @@
 - name: Replace registered runner  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
+    ACTIONS_RUNNER_INPUT_TOKEN: "{{ registration.json.token }}"
   ansible.builtin.command:
     "{{ runner_dir }}/config.sh \
     --url {{ github_full_url }} \
-    --token {{ registration.json.token }} \
     --name '{{ runner_name }}' \
     --labels {{ runner_labels | join(',') }} \
     --unattended \

--- a/tasks/install_runner_win.yml
+++ b/tasks/install_runner_win.yml
@@ -68,10 +68,10 @@
 - name: Register runner  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
+    ACTIONS_RUNNER_INPUT_TOKEN: "{{ registration.json.token }}"
   ansible.windows.win_command:
     "{{ runner_dir }}\\config.cmd \
     --url {{ github_full_url }} \
-    --token {{ registration.json.token }} \
     --name {{ runner_name }} \
     --labels {{ runner_labels | join(',') }} \
     --runnergroup {{ runner_group }} \
@@ -92,10 +92,10 @@
 - name: Replace registered runner  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
+    ACTIONS_RUNNER_INPUT_TOKEN: "{{ registration.json.token }}"
   ansible.windows.win_command:
     "{{ runner_dir }}\\config.cmd \
     --url {{ github_full_url }} \
-    --token {{ registration.json.token }} \
     --name {{ runner_name }} \
     --labels {{ runner_labels | join(',') }} \
     --runasservice \

--- a/tasks/uninstall_runner_unix.yml
+++ b/tasks/uninstall_runner_unix.yml
@@ -20,7 +20,8 @@
 - name: Unregister runner from the GitHub  # noqa no-changed-when
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
-  ansible.builtin.command: "./config.sh remove --token {{ registration.json.token }} --name '{{ runner_name }}' --unattended"
+    ACTIONS_RUNNER_INPUT_TOKEN: "{{ registration.json.token }}"
+  ansible.builtin.command: "./config.sh remove --name '{{ runner_name }}' --unattended"
   args:
     chdir: "{{ runner_dir }}"
   become: true

--- a/tasks/uninstall_runner_win.yml
+++ b/tasks/uninstall_runner_win.yml
@@ -31,7 +31,8 @@
 - name: Unregister runner from the GitHub
   environment:
     RUNNER_ALLOW_RUNASROOT: "1"
-  ansible.windows.win_command: "config.cmd remove --token {{ registration.json.token }} --name {{ runner_name }} --unattended"
+    ACTIONS_RUNNER_INPUT_TOKEN: "{{ registration.json.token }}"
+  ansible.windows.win_command: "config.cmd remove --name {{ runner_name }} --unattended"
   args:
     chdir: "{{ runner_dir }}"
   become: true


### PR DESCRIPTION
# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

Avoid logging the value of the `token` by removing it from the command line (which Ansible will output on failure) and into an environment variable (which will not be logged).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `master` branch.
--->

Unix tasks were tested via running my company workflows with and without this fix and `hide_sensitive_logs: false`, knowing that due to #238 I would see the registration command fail.

Without the fix, the token was logged, with the fix the token was not logged.

Unfortunately the Windows tasks have not been tested - I don't have any Ansible Windows hosts configured so nothing to run them against. This seems like relatively basic/core functionality so I don't see there being behavioural differences in them, but I can't guarantee.