### PR TITLE
Windows install fails in check mode

### DIFF
--- a/tasks/install_runner_win.yml
+++ b/tasks/install_runner_win.yml
@@ -120,6 +120,7 @@
 - name: Read service name from file
   ansible.windows.win_shell: "type {{ runner_dir }}\\.service"
   register: runner_service
+  check_mode: false
   changed_when: false
 
 - name: START and enable Github Actions Runner service


### PR DESCRIPTION
# Description

When running a Windows install in check mode, you get the following error:
```
Error: : Task failed: Finalization of task args for 'ansible.windows.win_service' failed: Error while resolving value for 'name': object of type 'dict' has no attribute 'stdout'
```

This is because the step to retrieve the service name doesn't run in check mode. I simply added `check_mode: false` to address this issue. Alternatively, this could be updated to use `ansible.builtin.slurp` like it does in the Unix logic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Tested manually on Windows 11.